### PR TITLE
Make JID parts public

### DIFF
--- a/jid.go
+++ b/jid.go
@@ -6,9 +6,9 @@ import (
 )
 
 type Jid struct {
-	username string
-	domain   string
-	resource string
+	Local    string
+	Domain   string
+	Resource string
 }
 
 func NewJid(sjid string) (jid *Jid, err error) {
@@ -18,16 +18,16 @@ func NewJid(sjid string) (jid *Jid, err error) {
 		return
 	}
 	jid = new(Jid)
-	jid.username = s1[0]
+	jid.Local = s1[0]
 
 	s2 := strings.Split(s1[1], "/")
 	if len(s2) > 2 {
 		err = errors.New("invalid JID: " + sjid)
 		return
 	}
-	jid.domain = s2[0]
+	jid.Domain = s2[0]
 	if len(s2) == 2 {
-		jid.resource = s2[1]
+		jid.Resource = s2[1]
 	}
 
 	return

--- a/jid_test.go
+++ b/jid_test.go
@@ -15,19 +15,19 @@ func TestValidJids(t *testing.T) {
 			t.Error("could not parse correct jid")
 		}
 
-		if jid.username != "test" {
+		if jid.Local != "test" {
 			t.Error("incorrect jid username")
 		}
 
-		if jid.domain != "domain.com" {
+		if jid.Domain != "domain.com" {
 			t.Error("incorrect jid domain")
 		}
 
-		if i == 0 && jid.resource != "" {
+		if i == 0 && jid.Resource != "" {
 			t.Error("bare jid resource should be empty")
 		}
 
-		if i == 1 && jid.resource != "resource" {
+		if i == 1 && jid.Resource != "resource" {
 			t.Error("incorrect full jid resource")
 		}
 	}

--- a/session.go
+++ b/session.go
@@ -37,7 +37,7 @@ func NewSession(conn net.Conn, o Options) (net.Conn, *Session, error) {
 
 	// starttls
 	var tlsConn net.Conn
-	tlsConn = s.startTlsIfSupported(conn, o.parsedJid.domain)
+	tlsConn = s.startTlsIfSupported(conn, o.parsedJid.Domain)
 	if s.TlsEnabled {
 		s.reset(conn, tlsConn, o)
 	}
@@ -64,7 +64,7 @@ func (s *Session) PacketId() string {
 
 func (s *Session) init(conn net.Conn, o Options) {
 	s.setProxy(nil, conn, o)
-	s.Features = s.open(o.parsedJid.domain)
+	s.Features = s.open(o.parsedJid.Domain)
 }
 
 func (s *Session) reset(conn net.Conn, newConn net.Conn, o Options) {
@@ -73,7 +73,7 @@ func (s *Session) reset(conn net.Conn, newConn net.Conn, o Options) {
 	}
 
 	s.setProxy(conn, newConn, o)
-	s.Features = s.open(o.parsedJid.domain)
+	s.Features = s.open(o.parsedJid.Domain)
 }
 
 // TODO: setProxyLogger ? better name ? This is not a TCP / HTTP proxy
@@ -140,7 +140,7 @@ func (s *Session) auth(o Options) {
 		return
 	}
 
-	s.err = authSASL(s.socketProxy, s.decoder, s.Features, o.parsedJid.username, o.Password)
+	s.err = authSASL(s.socketProxy, s.decoder, s.Features, o.parsedJid.Local, o.Password)
 }
 
 func (s *Session) bind(o Options) {
@@ -149,7 +149,7 @@ func (s *Session) bind(o Options) {
 	}
 
 	// Send IQ message asking to bind to the local user name.
-	var resource = o.parsedJid.resource
+	var resource = o.parsedJid.Resource
 	if resource != "" {
 		fmt.Fprintf(s.socketProxy, "<iq type='set' id='%s'><bind xmlns='%s'><resource>%s</resource></bind></iq>",
 			s.PacketId(), nsBind, resource)


### PR DESCRIPTION
I am writing a MUC like server component with this library. My server component have to get and interpret each part of JID such as local part, domain part, and resource part. Public API to access to each part is required, because my sever component code is in out of this xmpp package.

I made each field public, simply. I renamed from `username` to `Local` to accord to [RFC 7622](https://tools.ietf.org/html/rfc7622).

Thank you for your great project.