### PR TITLE
Support Go Modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module gosrc.io/xmpp
+
+go 1.9
+
+require (
+	github.com/google/go-cmp v0.2.0
+	github.com/processone/mpg123 v0.0.0-20160212185547-a17074c7ddc0
+	github.com/processone/soundcloud v0.0.0-20160217145628-430ee371ebce
+	golang.org/x/net v0.0.0-20190110200230-915654e7eabc // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
+github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/processone/mpg123 v0.0.0-20160212185547-a17074c7ddc0 h1:7Sb9wi06laajixrlpOJACEtAsnbDYlH8/bRTfLKAiF4=
+github.com/processone/mpg123 v0.0.0-20160212185547-a17074c7ddc0/go.mod h1:e9Ud3cx6fZEPqmEYDqjIsRvgFRPvXWhb0H1Cmu+LUtk=
+github.com/processone/soundcloud v0.0.0-20160217145628-430ee371ebce h1:lDqQi4xGLeS5mZYpVeyle5num0mWdyy37QmsQiFSX1Y=
+github.com/processone/soundcloud v0.0.0-20160217145628-430ee371ebce/go.mod h1:QfHw5V3JsrdJoYH4aD2+lr18v97eA6wyHaV0Zi+FuOI=
+golang.org/x/net v0.0.0-20190110200230-915654e7eabc h1:Yx9JGxI1SBhVLFjpAkWMaO1TF+xyqtHLjZpvQboJGiM=
+golang.org/x/net v0.0.0-20190110200230-915654e7eabc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=


### PR DESCRIPTION
Hello,

Please consider supporting [Go Modules], the new packaging standard that will be on by default Go 1.12. Experimental support is in Go 1.11 and the new module paths are supported in Go 1.9.7+ and Go 1.10.3+ in a read-only manner for backwards compatibility with all supported versions of Go.

Because this library is still below version 2, and has few external dependencies, the [`go.mod`] file is fairly simple. If you accept this PR, the only other thing to do would be to start using semver compatible tags and tag a release of this library that others can pin to (for example `v0.0.1`, or `v1.0.0` depending on your development process).

Note that I set the language version go 1.9 in the mod file because 1.9.7 is the earliest version with partial support for reading the `go.mod` file (earlier versions will keep working as they always have and won't read the go.mod file) and it did not appear that you were using any standard library or language features introduced after 1.9 (it builds fine with 1.9.7). Naturally this can change if you only support a later version of Go.

Using modules if future changes are made to this library is relatively simple; `go get -u` on Go 1.11 with modules on or 1.12 by default will update dependencies (not a problem here), and `go mod tidy` will trim down any dependencies that have been removed (or add any new dependencies it finds). I'd be happy to provide more information, or a quick crash course in using modules if you want to familiarize yourself with them.

Also note that I have submitted https://github.com/processone/mpg123/pull/1 and https://github.com/processone/soundcloud/pull/1, so if they decide to merge them and tag a release you can update to pinning to the tag which will make the `go.mod` file a bit easier to read. Of course, it doesn't really matter either way, it's just more obvious to humans what version is used if it's a nice looking tag.

Thank you for your consideration.

[Go Modules]: https://github.com/golang/go/wiki/Modules
[`go.mod`]: https://tip.golang.org/cmd/go/#hdr-The_go_mod_file