### PR TITLE
Parse show, status, and priority of presence stanzas as child elements

### DIFF
--- a/presence.go
+++ b/presence.go
@@ -8,9 +8,9 @@ import "encoding/xml"
 type Presence struct {
 	XMLName xml.Name `xml:"presence"`
 	PacketAttrs
-	Show     string `xml:"show,attr,omitempty"` // away, chat, dnd, xa
-	Status   string `xml:"status,attr,omitempty"`
-	Priority string `xml:"priority,attr,omitempty"`
+	Show     string `xml:"show,omitempty"` // away, chat, dnd, xa
+	Status   string `xml:"status,omitempty"`
+	Priority string `xml:"priority,omitempty"`
 	Error    Err    `xml:"error,omitempty"`
 }
 


### PR DESCRIPTION
Currently, show, status, and priority are parsed as attributes of a presence stanza. According to section 2.2.2 of the XMPP spec (https://xmpp.org/rfcs/rfc3921.html), these should be child elements of the presence stanza - this pull request aligns this library with the XMPP specification