### PR TITLE
Fixed infinite retries for failed TCP dial

### DIFF
--- a/client.go
+++ b/client.go
@@ -119,7 +119,7 @@ func (c *Client) Connect() (*Session, error) {
 	var try = 0
 	var success bool
 	c.Metrics = initMetrics()
-	for try <= c.config.Retry || !success {
+	for try <= c.config.Retry && !success {
 		if tcpconn, err = net.DialTimeout("tcp", c.config.Address, time.Duration(c.config.ConnectTimeout)*time.Second); err == nil {
 			c.Metrics.setConnectTime()
 			success = true


### PR DESCRIPTION
Currently, when connecting to the XMPP server, as long as success is false the program will continually try to reconnect. This seems at odds with having a Retry config option in config.go indicating "Number of retries for connect". This pull requests results in a limited amount of retries as specificied by Retry.