### PR TITLE
Closed receiver chan on error

### DIFF
--- a/client.go
+++ b/client.go
@@ -150,6 +150,7 @@ func (c *Client) recv(receiver chan<- interface{}) (err error) {
 	for {
 		val, err := next(c.Session.decoder)
 		if err != nil {
+			close(receiver)
 			return err
 		}
 		receiver <- val


### PR DESCRIPTION
Currently,  when next(c.Session.decoder) produces an error in recv(), the returned error is ignored as recv() is run in a goroutine. This proposed change allows the caller of Recv() to know when recv() has stopped processing packets and act accordingly.