### PR TITLE
Add support for parsing message extensions

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -105,12 +105,10 @@ type auth struct {
 }
 
 type BindBind struct {
+	IQPayload
 	XMLName  xml.Name `xml:"urn:ietf:params:xml:ns:xmpp-bind bind"`
 	Resource string   `xml:"resource,omitempty"`
 	Jid      string   `xml:"jid,omitempty"`
-}
-
-func (*BindBind) IsIQPayload() {
 }
 
 // Session is obsolete in RFC 6121.

--- a/cmd/xmpp-check/xmpp-check.go
+++ b/cmd/xmpp-check/xmpp-check.go
@@ -29,7 +29,6 @@ func main() {
 
 func runCheck(address, domain string) {
 	client, err := xmpp.NewChecker(address, domain)
-	// client, err := xmpp.NewChecker("mickael.m.in-app.io:5222", "mickael.m.in-app.io")
 
 	if err != nil {
 		log.Fatal("Error: ", err)

--- a/control_test.go
+++ b/control_test.go
@@ -3,8 +3,6 @@ package xmpp // import "gosrc.io/xmpp"
 import (
 	"encoding/xml"
 	"testing"
-
-	"gosrc.io/xmpp/iot"
 )
 
 func TestControlSet(t *testing.T) {
@@ -22,7 +20,7 @@ func TestControlSet(t *testing.T) {
 		t.Errorf("Unmarshal(%s) returned error", data)
 	}
 
-	if cs, ok := parsedIQ.Payload[0].(*iot.ControlSet); !ok {
+	if cs, ok := parsedIQ.Payload[0].(*ControlSet); !ok {
 		t.Errorf("Paylod is not an iot control set: %v", cs)
 	}
 }

--- a/iot_control.go
+++ b/iot_control.go
@@ -1,13 +1,13 @@
-package iot // import "gosrc.io/xmpp/iot"
+package xmpp // import "gosrc.io/xmpp/iot"
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+)
 
 type ControlSet struct {
+	IQPayload
 	XMLName xml.Name       `xml:"urn:xmpp:iot:control set"`
 	Fields  []ControlField `xml:",any"`
-}
-
-func (*ControlSet) IsIQPayload() {
 }
 
 type ControlGetForm struct {
@@ -21,8 +21,6 @@ type ControlField struct {
 }
 
 type ControlSetResponse struct {
+	IQPayload
 	XMLName xml.Name `xml:"urn:xmpp:iot:control setResponse"`
-}
-
-func (*ControlSetResponse) IsIQPayload() {
 }

--- a/iq.go
+++ b/iq.go
@@ -214,6 +214,7 @@ func (iq *IQ) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 					val := reflect.New(payloadType)
 					elt = val.Interface()
 				} else {
+					// TODO: Fix me. We do nothing of that element here.
 					elt = new(Node)
 				}
 
@@ -332,6 +333,8 @@ type DiscoItem struct {
 }
 
 // ============================================================================
+// TODO: Make it configurable at to be able to easily add new XMPP extensions
+//    in separate modules
 
 var typeRegistry = make(map[string]reflect.Type)
 

--- a/iq.go
+++ b/iq.go
@@ -210,7 +210,7 @@ func (iq *IQ) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 			if level <= 1 {
 				var elt interface{}
 				payloadType := tt.Name.Space + " " + tt.Name.Local
-				if payloadType := typeRegistry[payloadType]; payloadType != nil {
+				if payloadType := iqTypeRegistry[payloadType]; payloadType != nil {
 					val := reflect.New(payloadType)
 					elt = val.Interface()
 				} else {
@@ -332,15 +332,9 @@ type DiscoItem struct {
 	Node    string   `xml:"node,attr,omitempty"`
 }
 
-// ============================================================================
-// TODO: Make it configurable at to be able to easily add new XMPP extensions
-//    in separate modules
-
-var typeRegistry = make(map[string]reflect.Type)
-
 func init() {
-	typeRegistry["http://jabber.org/protocol/disco#info query"] = reflect.TypeOf(DiscoInfo{})
-	typeRegistry["http://jabber.org/protocol/disco#items query"] = reflect.TypeOf(DiscoItems{})
-	typeRegistry["urn:ietf:params:xml:ns:xmpp-bind bind"] = reflect.TypeOf(BindBind{})
-	typeRegistry["urn:xmpp:iot:control set"] = reflect.TypeOf(iot.ControlSet{})
+	iqTypeRegistry["http://jabber.org/protocol/disco#info query"] = reflect.TypeOf(DiscoInfo{})
+	iqTypeRegistry["http://jabber.org/protocol/disco#items query"] = reflect.TypeOf(DiscoItems{})
+	iqTypeRegistry["urn:ietf:params:xml:ns:xmpp-bind bind"] = reflect.TypeOf(BindBind{})
+	iqTypeRegistry["urn:xmpp:iot:control set"] = reflect.TypeOf(iot.ControlSet{})
 }

--- a/message.go
+++ b/message.go
@@ -86,8 +86,7 @@ func (msg *Message) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 		switch tt := t.(type) {
 
 		case xml.StartElement:
-			elementType := tt.Name.Space
-			if msgExt := typeRegistry.getmsgType(elementType); msgExt != nil {
+			if msgExt := typeRegistry.GetMsgExtension(tt.Name); msgExt != nil {
 				// Decode message extension
 				err = d.DecodeElement(msgExt, &tt)
 				if err != nil {

--- a/message_test.go
+++ b/message_test.go
@@ -27,3 +27,57 @@ func TestGenerateMessage(t *testing.T) {
 		t.Errorf("non matching items\n%s", cmp.Diff(parsedMessage, message))
 	}
 }
+
+func TestDecodeError(t *testing.T) {
+	str := `<message from='juliet@capulet.com'
+         id='msg_1'
+         to='romeo@montague.lit'
+         type='error'>
+  <error type='cancel'>
+    <not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
+  </error>
+</message>`
+
+	parsedMessage := xmpp.Message{}
+	if err := xml.Unmarshal([]byte(str), &parsedMessage); err != nil {
+		t.Errorf("message error stanza unmarshall error: %v", err)
+		return
+	}
+	if parsedMessage.Error.Type != "cancel" {
+		t.Errorf("incorrect error type: %s", parsedMessage.Error.Type)
+	}
+}
+
+func TestDecodeXEP0184(t *testing.T) {
+	str := `<message
+    from='northumberland@shakespeare.lit/westminster'
+    id='richard2-4.1.247'
+    to='kingrichard@royalty.england.lit/throne'>
+  <body>My lord, dispatch; read o'er these articles.</body>
+  <request xmlns='urn:xmpp:receipts'/>
+</message>`
+	parsedMessage := xmpp.Message{}
+	if err := xml.Unmarshal([]byte(str), &parsedMessage); err != nil {
+		t.Errorf("message receipt unmarshall error: %v", err)
+		return
+	}
+
+	if parsedMessage.Body != "My lord, dispatch; read o'er these articles." {
+		t.Errorf("Unexpected body: '%s'", parsedMessage.Body)
+	}
+
+	if len(parsedMessage.Extensions) < 1 {
+		t.Errorf("no extension found on parsed message")
+		return
+	}
+
+	switch ext := parsedMessage.Extensions[0].(type) {
+	case *xmpp.Receipt:
+		if ext.XMLName.Local != "request" {
+			t.Errorf("unexpected extension: %s:%s", ext.XMLName.Space, ext.XMLName.Local)
+		}
+	default:
+		t.Errorf("could not find receipt extension")
+	}
+
+}

--- a/message_test.go
+++ b/message_test.go
@@ -47,37 +47,3 @@ func TestDecodeError(t *testing.T) {
 		t.Errorf("incorrect error type: %s", parsedMessage.Error.Type)
 	}
 }
-
-func TestDecodeXEP0184(t *testing.T) {
-	str := `<message
-    from='northumberland@shakespeare.lit/westminster'
-    id='richard2-4.1.247'
-    to='kingrichard@royalty.england.lit/throne'>
-  <body>My lord, dispatch; read o'er these articles.</body>
-  <request xmlns='urn:xmpp:receipts'/>
-</message>`
-	parsedMessage := xmpp.Message{}
-	if err := xml.Unmarshal([]byte(str), &parsedMessage); err != nil {
-		t.Errorf("message receipt unmarshall error: %v", err)
-		return
-	}
-
-	if parsedMessage.Body != "My lord, dispatch; read o'er these articles." {
-		t.Errorf("Unexpected body: '%s'", parsedMessage.Body)
-	}
-
-	if len(parsedMessage.Extensions) < 1 {
-		t.Errorf("no extension found on parsed message")
-		return
-	}
-
-	switch ext := parsedMessage.Extensions[0].(type) {
-	case *xmpp.Receipt:
-		if ext.XMLName.Local != "request" {
-			t.Errorf("unexpected extension: %s:%s", ext.XMLName.Space, ext.XMLName.Local)
-		}
-	default:
-		t.Errorf("could not find receipt extension")
-	}
-
-}

--- a/msg_chat_markers.go
+++ b/msg_chat_markers.go
@@ -1,4 +1,4 @@
-package xmpp
+package xmpp // import "gosrc.io/xmpp"
 
 import "encoding/xml"
 

--- a/msg_chat_markers.go
+++ b/msg_chat_markers.go
@@ -1,0 +1,24 @@
+package xmpp
+
+import "encoding/xml"
+
+/*
+Support for:
+- XEP-0333 - Chat Markers: https://xmpp.org/extensions/xep-0333.html
+*/
+
+type Markable struct {
+	MsgExtension
+	XMLName xml.Name `xml:"urn:xmpp:chat-markers:0 markable"`
+}
+
+type MarkReceived struct {
+	MsgExtension
+	XMLName xml.Name `xml:"urn:xmpp:chat-markers:0 received"`
+	ID      string
+}
+
+func init() {
+	typeRegistry.MapExtension(PKTMessage, xml.Name{"urn:xmpp:chat-markers:0", "markable"}, Markable{})
+	typeRegistry.MapExtension(PKTMessage, xml.Name{"urn:xmpp:chat-markers:0", "received"}, MarkReceived{})
+}

--- a/msg_oob.go
+++ b/msg_oob.go
@@ -1,0 +1,19 @@
+package xmpp // import "gosrc.io/xmpp"
+
+import "encoding/xml"
+
+/*
+Support for:
+- XEP-0066 - Out of Band Data: https://xmpp.org/extensions/xep-0066.html
+*/
+
+type OOB struct {
+	MsgExtension
+	XMLName xml.Name `xml:"jabber:x:oob x"`
+	URL     string   `xml:"url"`
+	Desc    string   `xml:"desc,omitempty"`
+}
+
+func init() {
+	typeRegistry.MapExtension(PKTMessage, xml.Name{"jabber:x:oob", "x"}, OOB{})
+}

--- a/msg_receipts.go
+++ b/msg_receipts.go
@@ -1,4 +1,4 @@
-package xmpp
+package xmpp // import "gosrc.io/xmpp"
 
 import "encoding/xml"
 

--- a/msg_receipts.go
+++ b/msg_receipts.go
@@ -7,17 +7,19 @@ Support for:
 - XEP-0184 - Message Delivery Receipts: https://xmpp.org/extensions/xep-0184.html
 */
 
-const (
-	NSReceipts = "urn:xmpp:receipts"
-)
-
-// XEP-0184 message receipt markers
-type Receipt struct {
+// Used on outgoing message, to tell the recipient that you are requesting a message receipt / ack.
+type ReceiptRequest struct {
 	MsgExtension
-	XMLName xml.Name
-	Id      string
+	XMLName xml.Name `xml:"urn:xmpp:receipts request"`
+}
+
+type ReceiptReceived struct {
+	MsgExtension
+	XMLName xml.Name `xml:"urn:xmpp:receipts received"`
+	ID      string
 }
 
 func init() {
-	typeRegistry.RegisterMsgExt(NSReceipts, Receipt{})
+	typeRegistry.MapExtension(PKTMessage, xml.Name{"urn:xmpp:receipts", "request"}, ReceiptRequest{})
+	typeRegistry.MapExtension(PKTMessage, xml.Name{"urn:xmpp:receipts", "received"}, ReceiptReceived{})
 }

--- a/msg_receipts.go
+++ b/msg_receipts.go
@@ -1,0 +1,23 @@
+package xmpp
+
+import "encoding/xml"
+
+/*
+Support for:
+- XEP-0184 - Message Delivery Receipts: https://xmpp.org/extensions/xep-0184.html
+*/
+
+const (
+	NSReceipts = "urn:xmpp:receipts"
+)
+
+// XEP-0184 message receipt markers
+type Receipt struct {
+	MsgExtension
+	XMLName xml.Name
+	Id      string
+}
+
+func init() {
+	typeRegistry.RegisterMsgExt(NSReceipts, Receipt{})
+}

--- a/msg_receipts_test.go
+++ b/msg_receipts_test.go
@@ -1,0 +1,42 @@
+package xmpp_test
+
+import (
+	"encoding/xml"
+	"testing"
+
+	"gosrc.io/xmpp"
+)
+
+func TestDecodeRequest(t *testing.T) {
+	str := `<message
+    from='northumberland@shakespeare.lit/westminster'
+    id='richard2-4.1.247'
+    to='kingrichard@royalty.england.lit/throne'>
+  <body>My lord, dispatch; read o'er these articles.</body>
+  <request xmlns='urn:xmpp:receipts'/>
+</message>`
+	parsedMessage := xmpp.Message{}
+	if err := xml.Unmarshal([]byte(str), &parsedMessage); err != nil {
+		t.Errorf("message receipt unmarshall error: %v", err)
+		return
+	}
+
+	if parsedMessage.Body != "My lord, dispatch; read o'er these articles." {
+		t.Errorf("Unexpected body: '%s'", parsedMessage.Body)
+	}
+
+	if len(parsedMessage.Extensions) < 1 {
+		t.Errorf("no extension found on parsed message")
+		return
+	}
+
+	switch ext := parsedMessage.Extensions[0].(type) {
+	case *xmpp.ReceiptRequest:
+		if ext.XMLName.Local != "request" {
+			t.Errorf("unexpected extension: %s:%s", ext.XMLName.Space, ext.XMLName.Local)
+		}
+	default:
+		t.Errorf("could not find receipts extension")
+	}
+
+}

--- a/pep.go
+++ b/pep.go
@@ -1,29 +1,21 @@
-package pep // import "gosrc.io/xmpp/pep"
+package xmpp // import "gosrc.io/xmpp/pep"
 
 import (
 	"encoding/xml"
-
-	"gosrc.io/xmpp"
 )
 
-type iq struct {
-	XMLName          xml.Name `xml:"jabber:client iq"`
-	C                pubSub   // c for "contains"
-	xmpp.PacketAttrs          // Rename h for "header" ?
-}
-
-type pubSub struct {
+type PubSub struct {
 	XMLName xml.Name `xml:"http://jabber.org/protocol/pubsub pubsub"`
-	Publish publish
+	Publish Publish
 }
 
-type publish struct {
+type Publish struct {
 	XMLName xml.Name `xml:"publish"`
 	Node    string   `xml:"node,attr"`
-	Item    item
+	Item    Item
 }
 
-type item struct {
+type Item struct {
 	XMLName xml.Name `xml:"item"`
 	Tune    Tune
 }
@@ -66,11 +58,6 @@ type Tune struct {
 	uri    string
 }
 */
-
-func (t *Tune) XMPPFormat() (s string) {
-	packet, _ := xml.Marshal(iq{PacketAttrs: xmpp.PacketAttrs{Id: "tunes", Type: "set"}, C: pubSub{Publish: publish{Node: "http://jabber.org/protocol/tune", Item: item{Tune: *t}}}})
-	return string(packet)
-}
 
 /*
 func (*Tune) XMPPFormat() string {

--- a/registry.go
+++ b/registry.go
@@ -1,0 +1,65 @@
+package xmpp
+
+import (
+	"reflect"
+	"sync"
+)
+
+type MsgExtension interface{}
+
+// The Registry for msg and IQ types is a global variable.
+// TODO: Move to the client init process to remove the dependency on a global variable.
+//   That should make it possible to be able to share the decoder.
+// TODO: Ensure that a client can add its own custom namespace to the registry (or overload existing ones).
+var typeRegistry = newRegistry()
+
+type namespace = string
+
+type registry struct {
+	// Key is namespace of message extension
+	msgTypes     map[namespace]reflect.Type
+	msgTypesLock *sync.RWMutex
+
+	iqTypes map[namespace]reflect.Type
+}
+
+func newRegistry() registry {
+	return registry{
+		msgTypes:     make(map[namespace]reflect.Type),
+		msgTypesLock: &sync.RWMutex{},
+		iqTypes:      make(map[namespace]reflect.Type),
+	}
+}
+
+// Mutexes are not needed when adding a Message or IQ extension in init function.
+// However, forcing the use of the mutex protect the data structure against unexpected use
+// of the registry by developers using the library.
+func (r registry) RegisterMsgExt(namespace string, extension MsgExtension) {
+	r.msgTypesLock.Lock()
+	defer r.msgTypesLock.Unlock()
+	r.msgTypes[namespace] = reflect.TypeOf(extension)
+}
+
+func (r registry) getMsgExtType(namespace string) reflect.Type {
+	r.msgTypesLock.RLock()
+	defer r.msgTypesLock.RUnlock()
+	return r.msgTypes[namespace]
+}
+
+func (r registry) getmsgType(namespace string) MsgExtension {
+	if extensionType := r.getMsgExtType(namespace); extensionType != nil {
+		val := reflect.New(extensionType)
+		elt := val.Interface()
+		if msgExt, ok := elt.(MsgExtension); ok {
+			return msgExt
+		}
+	}
+	return nil
+}
+
+// Registry to support message extensions
+//var msgTypeRegistry = make(map[string]reflect.Type)
+
+// Registry to instantiate the right IQ payload element
+// Key is namespace and key of the payload
+var iqTypeRegistry = make(map[string]reflect.Type)

--- a/registry_test.go
+++ b/registry_test.go
@@ -1,0 +1,47 @@
+package xmpp // import "gosrc.io/xmpp"
+
+import (
+	"encoding/xml"
+	"reflect"
+	"testing"
+)
+
+func TestRegistry_RegisterMsgExt(t *testing.T) {
+	// Setup registry
+	typeRegistry := newRegistry()
+
+	// Register an element
+	name := xml.Name{Space: "urn:xmpp:receipts", Local: "request"}
+	typeRegistry.MapExtension(PKTMessage, name, ReceiptRequest{})
+
+	// Match that element
+	receipt := typeRegistry.GetMsgExtension(name)
+	if receipt == nil {
+		t.Error("cannot read element type from registry")
+		return
+	}
+
+	switch r := receipt.(type) {
+	case *ReceiptRequest:
+	default:
+		t.Errorf("Registry did not return expected type ReceiptRequest: %v", reflect.TypeOf(r))
+	}
+}
+
+func BenchmarkRegistryGet(b *testing.B) {
+	// Setup registry
+	typeRegistry := newRegistry()
+
+	// Register an element
+	name := xml.Name{Space: "urn:xmpp:receipts", Local: "request"}
+	typeRegistry.MapExtension(PKTMessage, name, ReceiptRequest{})
+
+	for i := 0; i < b.N; i++ {
+		// Match that element
+		receipt := typeRegistry.GetExtensionType(PKTMessage, name)
+		if receipt == nil {
+			b.Error("cannot read element type from registry")
+			return
+		}
+	}
+}


### PR DESCRIPTION
- Add a registry structure and merge it with IQ Payload registry
- Add support for parsing receipts, chat markers and out of band image urls.
- Clean up the IQPayload interface / marker for IQ payload