### PR TITLE
Add Client Manager to monitor connection state and trigger reconnect

### DIFF
--- a/backoff.go
+++ b/backoff.go
@@ -1,0 +1,101 @@
+/*
+Interesting reference on backoff:
+- Exponential Backoff And Jitter (AWS Blog):
+  https://www.awsarchitectureblog.com/2015/03/backoff.html
+
+We use Jitter as a default for exponential backoff, as the goal of
+this module is not to provide precise 'ticks', but good behaviour to
+implement retries that are helping the server to recover faster in
+case of congestion.
+
+It can be used in several ways:
+- Using duration to get next sleep time.
+- Using ticker channel to trigger callback function on tick
+
+The functions for Backoff are not threadsafe, but you can:
+- Keep the attempt counter on your end and use DurationForAttempt(int)
+- Use lock in your own code to protect the Backoff structure.
+
+TODO: Implement Backoff Ticker channel
+TODO: Implement throttler interface. Throttler could be used to implement various reconnect strategies.
+*/
+
+package xmpp // import "gosrc.io/xmpp"
+
+import (
+	"math"
+	"math/rand"
+	"time"
+)
+
+const (
+	defaultBase   int = 20 // Backoff base, in ms
+	defaultFactor int = 2
+	defaultCap    int = 180000 // 3 minutes
+)
+
+// Backoff can provide increasing duration with the number of attempt
+// performed. The structure is used to support exponential backoff on
+// connection attempts to avoid hammering the server we are connecting
+// to.
+type Backoff struct {
+	NoJitter     bool
+	Base         int
+	Factor       int
+	Cap          int
+	lastDuration int
+	attempt      int
+}
+
+// Duration returns the duration to apply to the current attempt.
+func (b *Backoff) Duration() time.Duration {
+	d := b.DurationForAttempt(b.attempt)
+	b.attempt++
+	return d
+}
+
+// Wait sleeps for backoff duration for current attempt.
+func (b *Backoff) Wait() {
+	time.Sleep(b.Duration())
+}
+
+// DurationForAttempt returns a duration for an attempt number, in a stateless way.
+func (b *Backoff) DurationForAttempt(attempt int) time.Duration {
+	b.setDefault()
+	expBackoff := math.Min(float64(b.Cap), float64(b.Base)*math.Pow(float64(b.Factor), float64(b.attempt)))
+	d := int(math.Trunc(expBackoff))
+	if !b.NoJitter {
+		d = rand.Intn(d)
+	}
+	return time.Duration(d) * time.Millisecond
+}
+
+// Reset sets back the number of attempts to 0. This is to be called after a successfull operation has been performed,
+// to reset the exponential backoff interval.
+func (b *Backoff) Reset() {
+	b.attempt = 0
+}
+
+func (b *Backoff) setDefault() {
+	if b.Base == 0 {
+		b.Base = defaultBase
+	}
+
+	if b.Cap == 0 {
+		b.Cap = defaultCap
+	}
+
+	if b.Factor == 0 {
+		b.Factor = defaultFactor
+	}
+}
+
+/*
+We use full jitter as default for now as it seems to provide good behaviour for reconnect.
+
+Base is the default interval between attempts (if backoff Factor was equal to 1)
+
+Attempt is the number of retry for operation. If we start attempt at 0, first sleep equals base.
+
+Cap is the maximum sleep time duration we tolerate between attempts
+*/

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -1,0 +1,24 @@
+package xmpp_test
+
+import (
+	"testing"
+	"time"
+
+	"gosrc.io/xmpp"
+)
+
+func TestDurationForAttempt_NoJitter(t *testing.T) {
+	b := xmpp.Backoff{Base: 25, NoJitter: true}
+	bInMS := time.Duration(b.Base) * time.Millisecond
+	if b.DurationForAttempt(0) != bInMS {
+		t.Errorf("incorrect default duration for attempt #0 (%d) = %d", b.DurationForAttempt(0)/time.Millisecond, bInMS/time.Millisecond)
+	}
+	var prevDuration, d time.Duration
+	for i := 0; i < 10; i++ {
+		d = b.DurationForAttempt(i)
+		if !(d >= prevDuration) {
+			t.Errorf("duration should be increasing between attempts. #%d (%d) > %d", i, d, prevDuration)
+		}
+		prevDuration = d
+	}
+}

--- a/client.go
+++ b/client.go
@@ -163,7 +163,6 @@ func (c *Client) recv() (err error) {
 
 // Recv abstracts receiving preparsed XMPP packets from a channel.
 // Channel allow client to receive / dispatch packets in for range loop.
-// FIXME: The code will not work fine if the XMPP client calls Recv several times.
 // TODO: Deprecate this function in favor of reading directly from the RecvChannel
 func (c *Client) Recv() <-chan interface{} {
 	return c.RecvChannel

--- a/client_manager.go
+++ b/client_manager.go
@@ -5,20 +5,20 @@ import (
 	"time"
 )
 
-type postConnect func(c *Client)
+type PostConnect func(c *Client)
 
 // ClientManager supervises an XMPP client connection. Its role is to handle connection events and
 // apply reconnection strategy.
 type ClientManager struct {
 	Client      *Client
 	Session     *Session
-	PostConnect postConnect
+	PostConnect PostConnect
 }
 
 // NewClientManager creates a new client manager structure, intended to support
-// handling XMPP client state event changes and autotrigger reconnection
+// handling XMPP client state event changes and auto-trigger reconnection
 // based on ClientManager configuration.
-func NewClientManager(client *Client, pc postConnect) *ClientManager {
+func NewClientManager(client *Client, pc PostConnect) *ClientManager {
 	return &ClientManager{
 		Client:      client,
 		PostConnect: pc,
@@ -44,7 +44,7 @@ func (cm *ClientManager) Stop() {
 
 // connect manages the reconnection loop and apply the define backoff to avoid overloading the server.
 func (cm *ClientManager) connect() {
-	var backoff Backoff // TODO: Probably group backoff calculation features with connection manager.
+	var backoff Backoff // TODO: Group backoff calculation features with connection manager?
 
 	for {
 		var err error

--- a/client_manager.go
+++ b/client_manager.go
@@ -1,0 +1,95 @@
+package xmpp // import "gosrc.io/xmpp"
+
+import (
+	"log"
+	"time"
+)
+
+type postConnect func(c *Client)
+
+// ClientManager supervises an XMPP client connection. Its role is to handle connection events and
+// apply reconnection strategy.
+type ClientManager struct {
+	Client      *Client
+	Session     *Session
+	PostConnect postConnect
+}
+
+// NewClientManager creates a new client manager structure, intended to support
+// handling XMPP client state event changes and autotrigger reconnection
+// based on ClientManager configuration.
+func NewClientManager(client *Client, pc postConnect) *ClientManager {
+	return &ClientManager{
+		Client:      client,
+		PostConnect: pc,
+	}
+}
+
+// Start launch the connection loop
+func (cm *ClientManager) Start() {
+	cm.Client.config.Handler = func(e Event) {
+		if e.State == StateDisconnected {
+			cm.connect()
+		}
+	}
+	cm.connect()
+}
+
+// Stop cancels pending operations and terminates existing XMPP client.
+func (cm *ClientManager) Stop() {
+	// Remove on disconnect handler to avoid triggering reconnect
+	cm.Client.config.Handler = nil
+	cm.Client.Disconnect()
+}
+
+// connect manages the reconnection loop and apply the define backoff to avoid overloading the server.
+func (cm *ClientManager) connect() {
+	var backoff Backoff // TODO: Probably group backoff calculation features with connection manager.
+
+	for {
+		var err error
+		if cm.Client.Session, err = cm.Client.Connect(); err != nil {
+			log.Printf("Connection error: %v\n", err)
+			backoff.Wait()
+		} else {
+			break
+		}
+	}
+
+	if cm.PostConnect != nil {
+		cm.PostConnect(cm.Client)
+	}
+}
+
+// Client Metrics
+// ============================================================================
+
+type Metrics struct {
+	startTime time.Time
+	// ConnectTime returns the duration between client initiation of the TCP/IP
+	// connection to the server and actual TCP/IP session establishment.
+	// This time includes DNS resolution and can be slightly higher if the DNS
+	// resolution result was not in cache.
+	ConnectTime time.Duration
+	// LoginTime returns the between client initiation of the TCP/IP
+	// connection to the server and the return of the login result.
+	// This includes ConnectTime, but also XMPP level protocol negociation
+	// like starttls.
+	LoginTime time.Duration
+}
+
+// initMetrics set metrics with default value and define the starting point
+// for duration calculation (connect time, login time, etc).
+func initMetrics() *Metrics {
+	return &Metrics{
+		startTime: time.Now(),
+	}
+}
+
+func (m *Metrics) setConnectTime() {
+	m.ConnectTime = time.Since(m.startTime)
+}
+
+func (m *Metrics) setLoginTime() {
+	m.LoginTime = time.Since(m.startTime)
+}

--- a/cmd/xmpp_echo/xmpp_echo.go
+++ b/cmd/xmpp_echo/xmpp_echo.go
@@ -26,12 +26,8 @@ func main() {
 		log.Fatal("Error: ", err)
 	}
 
-	session, err := client.Connect()
-	if err != nil {
-		log.Fatal("Error: ", err)
-	}
-
-	fmt.Println("Stream opened, we have streamID = ", session.StreamId)
+	cm := xmpp.NewClientManager(client, nil)
+	cm.Start()
 
 	// Iterator to receive packets coming from our XMPP connection
 	for packet := range client.Recv() {

--- a/cmd/xmpp_echo/xmpp_echo.go
+++ b/cmd/xmpp_echo/xmpp_echo.go
@@ -36,7 +36,7 @@ func main() {
 	// Iterator to receive packets coming from our XMPP connection
 	for packet := range client.Recv() {
 		switch packet := packet.(type) {
-		case *xmpp.Message:
+		case xmpp.Message:
 			_, _ = fmt.Fprintf(os.Stdout, "Body = %s - from = %s\n", packet.Body, packet.From)
 			reply := xmpp.Message{PacketAttrs: xmpp.PacketAttrs{To: packet.From}, Body: packet.Body}
 			_ = client.Send(reply)

--- a/cmd/xmpp_echo/xmpp_echo.go
+++ b/cmd/xmpp_echo/xmpp_echo.go
@@ -28,6 +28,7 @@ func main() {
 
 	cm := xmpp.NewClientManager(client, nil)
 	cm.Start()
+	// connection can be stopped with cm.Stop().
 
 	// Iterator to receive packets coming from our XMPP connection
 	for packet := range client.Recv() {

--- a/cmd/xmpp_echo/xmpp_echo.go
+++ b/cmd/xmpp_echo/xmpp_echo.go
@@ -43,6 +43,4 @@ func main() {
 }
 
 // TODO create default command line client to send message or to send an arbitrary XMPP sequence from a file,
-// (using templates ?)
-
-// TODO: autoreconnect when connection is lost
+//   (using templates ?)

--- a/cmd/xmpp_jukebox/xmpp_jukebox.go
+++ b/cmd/xmpp_jukebox/xmpp_jukebox.go
@@ -101,8 +101,7 @@ func playSCURL(p *mpg123.Player, rawURL string) {
 
 func connectXmpp(jid string, password string, address string) (client *xmpp.Client, err error) {
 	xmppConfig := xmpp.Config{Address: address,
-		Jid: jid, Password: password, PacketLogger: os.Stdout, Insecure: true,
-		Retry: 10}
+		Jid: jid, Password: password, PacketLogger: os.Stdout, Insecure: true}
 
 	if client, err = xmpp.NewClient(xmppConfig); err != nil {
 		return

--- a/config.go
+++ b/config.go
@@ -12,10 +12,12 @@ type Config struct {
 	Password       string
 	PacketLogger   *os.File // Used for debugging
 	Lang           string   // TODO: should default to 'en'
-	Retry          int      // Number of retries for connect
 	ConnectTimeout int      // Connection timeout in seconds. Default to 15
 	// Insecure can be set to true to allow to open a session without TLS. If TLS
 	// is supported on the server, we will still try to use it.
 	Insecure      bool
 	CharsetReader func(charset string, input io.Reader) (io.Reader, error) // passed to xml decoder
+
+	// Callback used to get connection changes
+	Handler EventHandler
 }

--- a/config.go
+++ b/config.go
@@ -17,7 +17,4 @@ type Config struct {
 	// is supported on the server, we will still try to use it.
 	Insecure      bool
 	CharsetReader func(charset string, input io.Reader) (io.Reader, error) // passed to xml decoder
-
-	// Callback used to get connection changes
-	Handler EventHandler
 }

--- a/parser.go
+++ b/parser.go
@@ -39,7 +39,6 @@ func initDecoder(p *xml.Decoder) (sessionID string, err error) {
 			return
 		}
 	}
-	panic("unreachable")
 }
 
 // Scan XML token stream to find next StartElement.
@@ -47,7 +46,7 @@ func nextStart(p *xml.Decoder) (xml.StartElement, error) {
 	for {
 		t, err := p.Token()
 		if err == io.EOF {
-			return xml.StartElement{}, nil
+			return xml.StartElement{}, errors.New("connection closed")
 		}
 		if err != nil {
 			return xml.StartElement{}, fmt.Errorf("nextStart %s", err)
@@ -57,7 +56,6 @@ func nextStart(p *xml.Decoder) (xml.StartElement, error) {
 			return t, nil
 		}
 	}
-	panic("unreachable")
 }
 
 // next scans XML token stream for next element and then assign a structure to decode

--- a/session.go
+++ b/session.go
@@ -54,10 +54,6 @@ func NewSession(conn net.Conn, o Config) (net.Conn, *Session, error) {
 	s.bind(o)
 	s.rfc3921Session(o)
 
-	if o.Handler != nil {
-		o.Handler(Event{State: StateSessionEstablished})
-	}
-
 	return tlsConn, s, s.err
 }
 

--- a/session.go
+++ b/session.go
@@ -54,6 +54,10 @@ func NewSession(conn net.Conn, o Config) (net.Conn, *Session, error) {
 	s.bind(o)
 	s.rfc3921Session(o)
 
+	if o.Handler != nil {
+		o.Handler(Event{State: StateSessionEstablished})
+	}
+
 	return tlsConn, s, s.err
 }
 


### PR DESCRIPTION
- Support for exponential backoff on reconnect to be gentle on the server.
- Clean up client by moving metrics to the connection managers.

Fixes #21 
Improvements for #8