### PR TITLE
Turn ClientManager into StreamManager

### DIFF
--- a/_examples/go.mod
+++ b/_examples/go.mod
@@ -2,4 +2,10 @@ module gosrc.io/xmpp/_examples
 
 go 1.12
 
-require gosrc.io/xmpp v0.0.0-20190608091551-b7461ae97fed
+require (
+	github.com/processone/mpg123 v1.0.0
+	github.com/processone/soundcloud v1.0.0
+	gosrc.io/xmpp v0.0.0-20190608160922-63a29d5c218a
+)
+
+replace gosrc.io/xmpp => gosrc.io/xmpp v0.0.0-20190608160922-63a29d5c218a

--- a/_examples/go.sum
+++ b/_examples/go.sum
@@ -1,11 +1,8 @@
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
-github.com/processone/mpg123 v1.0.0 h1:o2WOyGZRM255or1Zc/LtF/jARn51B+9aQl72Qace0GA=
 github.com/processone/mpg123 v1.0.0/go.mod h1:X/FeL+h8vD1bYsG9tIWV3M2c4qNTZOficyvPVBP08go=
-github.com/processone/soundcloud v1.0.0 h1:/+i6+Yveb7Y6IFGDSkesYI+HddblzcRTQClazzVHxoE=
 github.com/processone/soundcloud v1.0.0/go.mod h1:kDLeWpkRtN3C8kIReQdxoiRi92P9xR6yW6qLOJnNWfY=
-golang.org/x/net v0.0.0-20190110200230-915654e7eabc h1:Yx9JGxI1SBhVLFjpAkWMaO1TF+xyqtHLjZpvQboJGiM=
 golang.org/x/net v0.0.0-20190110200230-915654e7eabc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522 h1:bhOzK9QyoD0ogCnFro1m2mz41+Ib0oOhfJnBp5MR4K4=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-gosrc.io/xmpp v0.0.0-20190608091551-b7461ae97fed h1:uLrripMKk85UZ0Kd9V2S7qQy2CM4kveMZkCBqBEOqmY=
-gosrc.io/xmpp v0.0.0-20190608091551-b7461ae97fed/go.mod h1:it3z4S42Sy7eHWFqwmdFJbygg7lCmbrhKeqK7HQSqSU=
+gosrc.io/xmpp v0.0.0-20190608160922-63a29d5c218a h1:TKUhPFlQkBLpoSTNgh4rX64T1FmObGcggIYl7d2q4vM=
+gosrc.io/xmpp v0.0.0-20190608160922-63a29d5c218a/go.mod h1:6NJG4vRCxQJMGLxIdroPLPd++FPLOmDqJdJEt2mu4kQ=

--- a/_examples/xmpp_echo/xmpp_echo.go
+++ b/_examples/xmpp_echo/xmpp_echo.go
@@ -28,7 +28,7 @@ func main() {
 
 	// If you pass the client to a connection manager, it will handle the reconnect policy
 	// for you automatically.
-	cm := xmpp.NewClientManager(client, nil)
+	cm := xmpp.NewStreamManager(client, nil)
 	err = cm.Start()
 	if err != nil {
 		log.Fatal(err)

--- a/_examples/xmpp_jukebox/xmpp_jukebox.go
+++ b/_examples/xmpp_jukebox/xmpp_jukebox.go
@@ -107,7 +107,7 @@ func connectXmpp(jid string, password string, address string) (client *xmpp.Clie
 		return
 	}
 
-	if _, err = client.Connect(); err != nil {
+	if err = client.Connect(); err != nil {
 		return
 	}
 	return

--- a/client.go
+++ b/client.go
@@ -109,7 +109,7 @@ func NewClient(config Config) (c *Client, err error) {
 		c.config.ConnectTimeout = 15 // 15 second as default
 	}
 
-	// Create a default channel that developer can override
+	// Create a default channel that developers can override
 	c.RecvChannel = make(chan interface{})
 
 	return

--- a/client.go
+++ b/client.go
@@ -143,7 +143,7 @@ func (c *Client) Connect() error {
 	}
 	c.updateState(StateConnected)
 
-	// Connection is ok, we now open XMPP session
+	// Client is ok, we now open XMPP session
 	if c.conn, c.Session, err = NewSession(c.conn, c.config); err != nil {
 		return err
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -31,7 +31,7 @@ func TestClient_Connect(t *testing.T) {
 		t.Errorf("connect create XMPP client: %s", err)
 	}
 
-	if _, err = client.Connect(); err != nil {
+	if err = client.Connect(); err != nil {
 		t.Errorf("XMPP connection failed: %s", err)
 	}
 
@@ -52,7 +52,7 @@ func TestClient_NoInsecure(t *testing.T) {
 		t.Errorf("cannot create XMPP client: %s", err)
 	}
 
-	if _, err = client.Connect(); err == nil {
+	if err = client.Connect(); err == nil {
 		// When insecure is not allowed:
 		t.Errorf("should fail as insecure connection is not allowed and server does not support TLS")
 	}

--- a/component.go
+++ b/component.go
@@ -58,7 +58,10 @@ type Component struct {
 }
 
 func NewComponent(opts ComponentOptions) (*Component, error) {
-	return &Component{ComponentOptions: opts}, nil
+	c := Component{ComponentOptions: opts}
+	// Create a default channel that developers can override
+	c.RecvChannel = make(chan interface{})
+	return &c, nil
 }
 
 // Connect triggers component connection to XMPP server component port.

--- a/component.go
+++ b/component.go
@@ -141,16 +141,6 @@ func (c *Component) recv() (err error) {
 			close(c.RecvChannel)
 			c.streamError(p.Error.Local, p.Text)
 			return errors.New("stream error: " + p.Error.Local)
-		case IQ:
-			switch inner := p.Payload[0].(type) {
-			// Our component module handle disco info but can let component implementation
-			// handle disco items queries
-			case *DiscoInfo:
-				if p.Type == "get" {
-					c.discoResult(p.PacketAttrs, inner)
-				}
-			}
-			break
 		}
 		c.RecvChannel <- val
 	}
@@ -247,3 +237,9 @@ func (c *Component) discoResult(attrs PacketAttrs, info *DiscoInfo) {
 
 	_ = c.Send(iq)
 }
+
+/*
+TODO: Add support for discovery management directly in component
+TODO: Support multiple identities on disco info
+TODO: Support returning features on disco info
+*/

--- a/component.go
+++ b/component.go
@@ -171,8 +171,9 @@ func (c *Component) Send(packet Packet) error {
 // disconnect the component. It is up to the user of this method to
 // carefully craft the XML content to produce valid XMPP.
 func (c *Component) SendRaw(packet string) error {
-	fmt.Fprintf(c.conn, packet)
-	return nil
+	var err error
+	_, err = fmt.Fprintf(c.conn, packet)
+	return err
 }
 
 // handshake generates an authentication token based on StreamID and shared secret.

--- a/component.go
+++ b/component.go
@@ -9,16 +9,47 @@ import (
 	"io"
 	"net"
 	"time"
+
+	"gosrc.io/xmpp"
 )
 
 const componentStreamOpen = "<?xml version='1.0'?><stream:stream to='%s' xmlns='%s' xmlns:stream='%s'>"
+
+type ComponentOptions struct {
+	// =================================
+	// Component Connection Info
+
+	// Domain is the XMPP server subdomain that the component will handle
+	Domain string
+	// Secret is the "password" used by the XMPP server to secure component access
+	Secret string
+	// Address is the XMPP Host and port to connect to. Host is of
+	// the form 'serverhost:port' i.e "localhost:8888"
+	Address string
+
+	// =================================
+	// Component discovery
+
+	// Component human readable name, that will be shown in XMPP discovery
+	Name string
+	// Typical categories and types: https://xmpp.org/registrar/disco-categories.html
+	Category string
+	Type     string
+
+	// =================================
+	// Communication with developer client / StreamManager
+
+	// Packet channel
+	RecvChannel chan interface{}
+	// Track and broadcast connection state
+	EventManager
+}
 
 // Component implements an XMPP extension allowing to extend XMPP server
 // using external components. Component specifications are defined
 // in XEP-0114, XEP-0355 and XEP-0356.
 type Component struct {
-	Host   string
-	Secret string
+	ComponentOptions
 
 	// TCP level connection
 	conn net.Conn
@@ -28,18 +59,22 @@ type Component struct {
 	decoder     *xml.Decoder
 }
 
+func NewComponent(opts ComponentOptions) (*Component, error) {
+	return &Component{ComponentOptions: opts}, nil
+}
+
 // Connect triggers component connection to XMPP server component port.
-// TODO Helper to prepare connection string
-func (c *Component) Connect(connStr string) error {
+// TODO: Failed handshake should be a permanent error
+func (c *Component) Connect() error {
 	var conn net.Conn
 	var err error
-	if conn, err = net.DialTimeout("tcp", connStr, time.Duration(5)*time.Second); err != nil {
+	if conn, err = net.DialTimeout("tcp", c.Address, time.Duration(5)*time.Second); err != nil {
 		return err
 	}
 	c.conn = conn
 
 	// 1. Send stream open tag
-	if _, err := fmt.Fprintf(conn, componentStreamOpen, c.Host, NSComponent, NSStream); err != nil {
+	if _, err := fmt.Fprintf(conn, componentStreamOpen, c.Domain, NSComponent, NSStream); err != nil {
 		return errors.New("cannot send stream open " + err.Error())
 	}
 	c.decoder = xml.NewDecoder(conn)
@@ -65,16 +100,59 @@ func (c *Component) Connect(connStr string) error {
 	case StreamError:
 		return errors.New("handshake failed " + v.Error.Local)
 	case Handshake:
+		// Start the receiver go routine
+		go c.recv()
 		return nil
 	default:
-		return errors.New("unexpected packet, got " + v.Name())
+		return errors.New("expecting handshake result, got " + v.Name())
 	}
 }
 
-// ReadPacket reads next incoming XMPP packet
-func (c *Component) ReadPacket() (Packet, error) {
-	// TODO use defined interface Packet
-	return next(c.decoder)
+func (c *Component) Disconnect() {
+	_ = c.SendRaw("</stream:stream>")
+	// TODO: Add a way to wait for stream close acknowledgement from the server for clean disconnect
+	_ = c.conn.Close()
+}
+
+func (c *Component) SetHandler(handler EventHandler) {
+	c.Handler = handler
+}
+
+// Recv abstracts receiving preparsed XMPP packets from a channel.
+// Channel allow client to receive / dispatch packets in for range loop.
+// TODO: Deprecate this function in favor of reading directly from the RecvChannel ?
+func (c *Component) Recv() <-chan interface{} {
+	return c.RecvChannel
+}
+
+func (c *Component) recv() (err error) {
+	for {
+		val, err := next(c.decoder)
+		if err != nil {
+			c.updateState(StateDisconnected)
+			return err
+		}
+
+		// Handle stream errors
+		switch p := val.(type) {
+		case StreamError:
+			c.RecvChannel <- val
+			close(c.RecvChannel)
+			c.streamError(p.Error.Local, p.Text)
+			return errors.New("stream error: " + p.Error.Local)
+		case xmpp.IQ:
+			switch inner := p.Payload[0].(type) {
+			// Our component module handle disco info but can let component implementation
+			// handle disco items queries
+			case *xmpp.DiscoInfo:
+				if p.Type == "get" {
+					c.discoResult(p.PacketAttrs, inner)
+				}
+			}
+			break
+		}
+		c.RecvChannel <- val
+	}
 }
 
 // Send marshalls XMPP stanza and sends it to the server.
@@ -141,4 +219,29 @@ func (handshakeDecoder) decode(p *xml.Decoder, se xml.StartElement) (Handshake, 
 	var packet Handshake
 	err := p.DecodeElement(&packet, &se)
 	return packet, err
+}
+
+// Service discovery
+
+func (c *Component) discoResult(attrs xmpp.PacketAttrs, info *xmpp.DiscoInfo) {
+	iq := xmpp.NewIQ("result", attrs.To, attrs.From, attrs.Id, "en")
+	var identity xmpp.Identity
+	if info.Node == "" {
+		identity = xmpp.Identity{
+			Name:     c.Name,
+			Category: c.Category,
+			Type:     c.Type,
+		}
+	}
+
+	payload := xmpp.DiscoInfo{
+		Identity: identity,
+		Features: []xmpp.Feature{
+			{Var: xmpp.NSDiscoInfo},
+			{Var: xmpp.NSDiscoItems},
+		},
+	}
+	iq.AddPayload(&payload)
+
+	_ = c.xmpp.Send(iq)
 }

--- a/component.go
+++ b/component.go
@@ -69,7 +69,6 @@ func (c *Component) Connect(connStr string) error {
 	default:
 		return errors.New("unexpected packet, got " + v.Name())
 	}
-	panic("unreachable")
 }
 
 // ReadPacket reads next incoming XMPP packet
@@ -96,7 +95,7 @@ func (c *Component) Send(packet Packet) error {
 // disconnect the component. It is up to the user of this method to
 // carefully craft the XML content to produce valid XMPP.
 func (c *Component) SendRaw(packet string) error {
-	fmt.Fprintf(c.conn, packet) // TODO handle errors
+	fmt.Fprintf(c.conn, packet)
 	return nil
 }
 

--- a/component.go
+++ b/component.go
@@ -9,8 +9,6 @@ import (
 	"io"
 	"net"
 	"time"
-
-	"gosrc.io/xmpp"
 )
 
 const componentStreamOpen = "<?xml version='1.0'?><stream:stream to='%s' xmlns='%s' xmlns:stream='%s'>"
@@ -140,11 +138,11 @@ func (c *Component) recv() (err error) {
 			close(c.RecvChannel)
 			c.streamError(p.Error.Local, p.Text)
 			return errors.New("stream error: " + p.Error.Local)
-		case xmpp.IQ:
+		case IQ:
 			switch inner := p.Payload[0].(type) {
 			// Our component module handle disco info but can let component implementation
 			// handle disco items queries
-			case *xmpp.DiscoInfo:
+			case *DiscoInfo:
 				if p.Type == "get" {
 					c.discoResult(p.PacketAttrs, inner)
 				}
@@ -223,25 +221,25 @@ func (handshakeDecoder) decode(p *xml.Decoder, se xml.StartElement) (Handshake, 
 
 // Service discovery
 
-func (c *Component) discoResult(attrs xmpp.PacketAttrs, info *xmpp.DiscoInfo) {
-	iq := xmpp.NewIQ("result", attrs.To, attrs.From, attrs.Id, "en")
-	var identity xmpp.Identity
+func (c *Component) discoResult(attrs PacketAttrs, info *DiscoInfo) {
+	iq := NewIQ("result", attrs.To, attrs.From, attrs.Id, "en")
+	var identity Identity
 	if info.Node == "" {
-		identity = xmpp.Identity{
+		identity = Identity{
 			Name:     c.Name,
 			Category: c.Category,
 			Type:     c.Type,
 		}
 	}
 
-	payload := xmpp.DiscoInfo{
+	payload := DiscoInfo{
 		Identity: identity,
-		Features: []xmpp.Feature{
-			{Var: xmpp.NSDiscoInfo},
-			{Var: xmpp.NSDiscoItems},
+		Features: []Feature{
+			{Var: NSDiscoInfo},
+			{Var: NSDiscoItems},
 		},
 	}
 	iq.AddPayload(&payload)
 
-	_ = c.xmpp.Send(iq)
+	_ = c.Send(iq)
 }

--- a/component_test.go
+++ b/component_test.go
@@ -3,10 +3,11 @@ package xmpp // import "gosrc.io/xmpp"
 import "testing"
 
 func TestHandshake(t *testing.T) {
-	c := Component{
-		Host:   "test.localhost",
+	opts := ComponentOptions{
+		Domain: "test.localhost",
 		Secret: "mypass",
 	}
+	c := Component{ComponentOptions: opts}
 
 	streamID := "1263952298440005243"
 	expected := "c77e2ef0109fbbc5161e83b51629cd1353495332"

--- a/config.go
+++ b/config.go
@@ -12,7 +12,7 @@ type Config struct {
 	Password       string
 	PacketLogger   *os.File // Used for debugging
 	Lang           string   // TODO: should default to 'en'
-	ConnectTimeout int      // Connection timeout in seconds. Default to 15
+	ConnectTimeout int      // Client timeout in seconds. Default to 15
 	// Insecure can be set to true to allow to open a session without TLS. If TLS
 	// is supported on the server, we will still try to use it.
 	Insecure      bool


### PR DESCRIPTION
The StreamManager can supervise and handle events for both an XMPP client or an XMPP component.

Fix #38 