### PR TITLE
wrong package import url let it failed

### DIFF
--- a/iq_test.go
+++ b/iq_test.go
@@ -1,4 +1,4 @@
-package xmpp_test // import "gosrc.io/xmpp_test"
+package xmpp_test
 
 import (
 	"encoding/xml"


### PR DESCRIPTION
Take a look here:
https://dev.sum7.eu/genofire/thrempp/-/jobs/1404

---

by the way, why does ProcessOne announce https://github.com/sheenobu/go-xco as xmpp component library ? : https://blog.process-one.net/real-time-stack-issue-23/