### PR TITLE
Add support for initial Router for packet matching & delegation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ coverage.txt
 # Do not commit codeship key
 codeship.aes
 codeship.env
+
+priv/

--- a/README.md
+++ b/README.md
@@ -37,30 +37,30 @@ func main() {
 		Insecure:     true,
 	}
 
-	client, err := xmpp.NewClient(config)
+	router := xmpp.NewRouter()
+	router.HandleFunc("message", HandleMessage)
+
+	client, err := xmpp.NewClient(config, router)
 	if err != nil {
 		log.Fatalf("%+v", err)
 	}
 
 	// If you pass the client to a connection manager, it will handle the reconnect policy
 	// for you automatically.
-	cm := xmpp.NewClientManager(client, nil)
-	err = cm.Start()
-	if err != nil {
-		log.Fatal(err)
+	cm := xmpp.NewStreamManager(client, nil)
+	log.Fatal(cm.Run())
+}
+
+func HandleMessage(s xmpp.Sender, p xmpp.Packet) {
+	msg, ok := p.(xmpp.Message)
+	if !ok {
+		_, _ = fmt.Fprintf(os.Stdout, "Ignoring packet: %T\n", p)
+		return
 	}
 
-	// Iterator to receive packets coming from our XMPP connection
-	for packet := range client.Recv() {
-		switch packet := packet.(type) {
-		case xmpp.Message:
-			_, _ = fmt.Fprintf(os.Stdout, "Body = %s - from = %s\n", packet.Body, packet.From)
-			reply := xmpp.Message{PacketAttrs: xmpp.PacketAttrs{To: packet.From}, Body: packet.Body}
-			_ = client.Send(reply)
-		default:
-			_, _ = fmt.Fprintf(os.Stdout, "Ignoring packet: %T\n", packet)
-		}
-	}
+	_, _ = fmt.Fprintf(os.Stdout, "Body = %s - from = %s\n", msg.Body, msg.From)
+	reply := xmpp.Message{PacketAttrs: xmpp.PacketAttrs{To: msg.From}, Body: msg.Body}
+	_ = s.Send(reply)
 }
 ```
 

--- a/_examples/delegation/README.md
+++ b/_examples/delegation/README.md
@@ -1,0 +1,5 @@
+# Advanced component: delegation
+
+`delegation` is an example of advanced component supporting Namespace Delegation
+([XEP-0355](https://xmpp.org/extensions/xep-0355.html)) and privileged entity
+([XEP-356](https://xmpp.org/extensions/xep-0356.html)).

--- a/_examples/delegation/delegation.go
+++ b/_examples/delegation/delegation.go
@@ -1,0 +1,227 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"gosrc.io/xmpp"
+)
+
+func main() {
+	opts := xmpp.ComponentOptions{
+		Domain:  "service.localhost",
+		Secret:  "mypass",
+		Address: "localhost:9999",
+
+		// TODO: Move that part to a component discovery handler
+		Name:     "Test Component",
+		Category: "gateway",
+		Type:     "service",
+	}
+
+	router := xmpp.NewRouter()
+	router.HandleFunc("message", HandleMessage)
+	router.NewRoute().
+		IQNamespaces(xmpp.NSDiscoInfo).
+		HandlerFunc(func(s xmpp.Sender, p xmpp.Packet) {
+			DiscoInfo(s, p, opts)
+		})
+	router.NewRoute().
+		IQNamespaces("urn:xmpp:delegation:1").
+		HandlerFunc(HandleDelegation)
+
+	component, err := xmpp.NewComponent(opts, router)
+	if err != nil {
+		log.Fatalf("%+v", err)
+	}
+
+	// If you pass the component to a stream manager, it will handle the reconnect policy
+	// for you automatically.
+	// TODO: Post Connect could be a feature of the router or the client. Move it somewhere else.
+	cm := xmpp.NewStreamManager(component, nil)
+	log.Fatal(cm.Run())
+}
+
+func HandleMessage(_ xmpp.Sender, p xmpp.Packet) {
+	msg, ok := p.(xmpp.Message)
+	if !ok {
+		return
+	}
+	var msgProcessed bool
+	for _, ext := range msg.Extensions {
+		delegation, ok := ext.(*xmpp.Delegation)
+		if ok {
+			msgProcessed = true
+			fmt.Printf("Delegation confirmed for namespace %s\n", delegation.Delegated.Namespace)
+		}
+	}
+	// TODO: Decode privilege message
+	// <message to='service.localhost' from='localhost'><privilege xmlns='urn:xmpp:privilege:1'><perm type='outgoing' access='message'/><perm type='get' access='roster'/><perm type='managed_entity' access='presence'/></privilege></message>
+
+	if !msgProcessed {
+		fmt.Printf("Ignored received message, not related to delegation: %v\n", msg)
+	}
+}
+
+const (
+	pubsubNode = "urn:xmpp:delegation:1::http://jabber.org/protocol/pubsub"
+	pepNode    = "urn:xmpp:delegation:1:bare:http://jabber.org/protocol/pubsub"
+)
+
+// TODO: replace xmpp.Sender by ctx xmpp.Context ?
+// ctx.Stream.Send / SendRaw
+// ctx.Opts
+func DiscoInfo(c xmpp.Sender, p xmpp.Packet, opts xmpp.ComponentOptions) {
+	// Type conversion & sanity checks
+	iq, ok := p.(xmpp.IQ)
+	if !ok {
+		return
+	}
+	info, ok := iq.Payload[0].(*xmpp.DiscoInfo)
+	if !ok {
+		return
+	}
+
+	iqResp := xmpp.NewIQ("result", iq.To, iq.From, iq.Id, "en")
+
+	switch info.Node {
+	case "":
+		DiscoInfoRoot(&iqResp, opts)
+	case pubsubNode:
+		DiscoInfoPubSub(&iqResp)
+	case pepNode:
+		DiscoInfoPEP(&iqResp)
+	}
+
+	_ = c.Send(iqResp)
+}
+
+func DiscoInfoRoot(iqResp *xmpp.IQ, opts xmpp.ComponentOptions) {
+	// Higher level discovery
+	identity := xmpp.Identity{
+		Name:     opts.Name,
+		Category: opts.Category,
+		Type:     opts.Type,
+	}
+	payload := xmpp.DiscoInfo{
+		XMLName: xml.Name{
+			Space: xmpp.NSDiscoInfo,
+			Local: "query",
+		},
+		Identity: identity,
+		Features: []xmpp.Feature{
+			{Var: xmpp.NSDiscoInfo},
+			{Var: xmpp.NSDiscoItems},
+			{Var: "jabber:iq:version"},
+			{Var: "urn:xmpp:delegation:1"},
+		},
+	}
+	iqResp.AddPayload(&payload)
+}
+
+func DiscoInfoPubSub(iqResp *xmpp.IQ) {
+	payload := xmpp.DiscoInfo{
+		XMLName: xml.Name{
+			Space: xmpp.NSDiscoInfo,
+			Local: "query",
+		},
+		Node: pubsubNode,
+		Features: []xmpp.Feature{
+			{Var: "http://jabber.org/protocol/pubsub"},
+			{Var: "http://jabber.org/protocol/pubsub#publish"},
+			{Var: "http://jabber.org/protocol/pubsub#subscribe"},
+			{Var: "http://jabber.org/protocol/pubsub#publish-options"},
+		},
+	}
+	iqResp.AddPayload(&payload)
+}
+
+func DiscoInfoPEP(iqResp *xmpp.IQ) {
+	identity := xmpp.Identity{
+		Category: "pubsub",
+		Type:     "pep",
+	}
+	payload := xmpp.DiscoInfo{
+		XMLName: xml.Name{
+			Space: xmpp.NSDiscoInfo,
+			Local: "query",
+		},
+		Identity: identity,
+		Node:     pepNode,
+		Features: []xmpp.Feature{
+			{Var: "http://jabber.org/protocol/pubsub#access-presence"},
+			{Var: "http://jabber.org/protocol/pubsub#auto-create"},
+			{Var: "http://jabber.org/protocol/pubsub#auto-subscribe"},
+			{Var: "http://jabber.org/protocol/pubsub#config-node"},
+			{Var: "http://jabber.org/protocol/pubsub#create-and-configure"},
+			{Var: "http://jabber.org/protocol/pubsub#create-nodes"},
+			{Var: "http://jabber.org/protocol/pubsub#filtered-notifications"},
+			{Var: "http://jabber.org/protocol/pubsub#persistent-items"},
+			{Var: "http://jabber.org/protocol/pubsub#publish"},
+			{Var: "http://jabber.org/protocol/pubsub#retrieve-items"},
+			{Var: "http://jabber.org/protocol/pubsub#subscribe"},
+		},
+	}
+	iqResp.AddPayload(&payload)
+}
+
+func HandleDelegation(s xmpp.Sender, p xmpp.Packet) {
+	// Type conversion & sanity checks
+	iq, ok := p.(xmpp.IQ)
+	if !ok {
+		return
+	}
+
+	payload1 := iq.Payload[0]
+	delegation, ok := payload1.(*xmpp.Delegation)
+	if !ok {
+		return
+	}
+	forwardedPacket := delegation.Forwarded.Stanza
+	fmt.Println(forwardedPacket)
+	forwardedIQ, ok := forwardedPacket.(xmpp.IQ)
+	if !ok {
+		return
+	}
+	payload := forwardedIQ.Payload
+	if len(payload) == 0 {
+		return
+	}
+
+	pubsub, ok := payload[0].(*xmpp.PubSub)
+	if !ok {
+		// We only support pubsub delegation
+		return
+	}
+
+	if pubsub.Publish.XMLName.Local == "publish" {
+		// Prepare pubsub IQ reply
+		iqResp := xmpp.NewIQ("result", forwardedIQ.To, forwardedIQ.From, forwardedIQ.Id, "en")
+		payload := xmpp.PubSub{
+			XMLName: xml.Name{
+				Space: "http://jabber.org/protocol/pubsub",
+				Local: "pubsub",
+			},
+		}
+		iqResp.AddPayload(&payload)
+		// Wrap the reply in delegation 'forward'
+		iqForward := xmpp.NewIQ("result", iq.To, iq.From, iq.Id, "en")
+		delegPayload := xmpp.Delegation{
+			XMLName: xml.Name{
+				Space: "urn:xmpp:delegation:1",
+				Local: "delegation",
+			},
+			Forwarded: &xmpp.Forwarded{
+				XMLName: xml.Name{
+					Space: "urn:xmpp:forward:0",
+					Local: "forward",
+				},
+				Stanza: iqResp,
+			},
+		}
+		iqForward.AddPayload(&delegPayload)
+		_ = s.Send(iqForward)
+		// TODO: The component should actually broadcast the mood to subscribers
+	}
+}

--- a/_examples/xmpp_component/README.md
+++ b/_examples/xmpp_component/README.md
@@ -3,6 +3,8 @@
 This component will connect to ejabberd and act as a subdomain "service" of your primary XMPP domain
 (in that case localhost).
 
+This component does nothing expect connect and show up in service discovery.
+
 To be able to connect this component, you need to add a listener to your XMPP server.
 
 Here is an example ejabberd configuration for that component listener:

--- a/_examples/xmpp_jukebox/xmpp_jukebox.go
+++ b/_examples/xmpp_jukebox/xmpp_jukebox.go
@@ -74,6 +74,7 @@ func processIq(client *xmpp.Client, p *mpg123.Player, packet *xmpp.IQ) {
 
 		playSCURL(p, url)
 		setResponse := new(xmpp.ControlSetResponse)
+		// FIXME: Broken
 		reply := xmpp.IQ{PacketAttrs: xmpp.PacketAttrs{To: packet.From, Type: "result", Id: packet.Id}, Payload: []xmpp.IQPayload{setResponse}}
 		_ = client.Send(reply)
 		// TODO add Soundclound artist / title retrieval
@@ -86,7 +87,7 @@ func processIq(client *xmpp.Client, p *mpg123.Player, packet *xmpp.IQ) {
 func sendUserTune(client *xmpp.Client, artist string, title string) {
 	tune := xmpp.Tune{Artist: artist, Title: title}
 	iq := xmpp.NewIQ("set", "", "", "usertune-1", "en")
-	payload := xmpp.PubSub{Publish: xmpp.Publish{Node: "http://jabber.org/protocol/tune", Item: xmpp.Item{Tune: tune}}}
+	payload := xmpp.PubSub{Publish: &xmpp.Publish{Node: "http://jabber.org/protocol/tune", Item: xmpp.Item{Tune: &tune}}}
 	iq.AddPayload(&payload)
 	_ = client.Send(iq)
 }

--- a/auth.go
+++ b/auth.go
@@ -102,10 +102,13 @@ type auth struct {
 }
 
 type BindBind struct {
-	IQPayload
 	XMLName  xml.Name `xml:"urn:ietf:params:xml:ns:xmpp-bind bind"`
 	Resource string   `xml:"resource,omitempty"`
 	Jid      string   `xml:"jid,omitempty"`
+}
+
+func (b *BindBind) Namespace() string {
+	return b.XMLName.Space
 }
 
 // Session is obsolete in RFC 6121.

--- a/client_test.go
+++ b/client_test.go
@@ -27,7 +27,8 @@ func TestClient_Connect(t *testing.T) {
 
 	var client *Client
 	var err error
-	if client, err = NewClient(config); err != nil {
+	router := NewRouter()
+	if client, err = NewClient(config, router); err != nil {
 		t.Errorf("connect create XMPP client: %s", err)
 	}
 
@@ -48,7 +49,8 @@ func TestClient_NoInsecure(t *testing.T) {
 
 	var client *Client
 	var err error
-	if client, err = NewClient(config); err != nil {
+	router := NewRouter()
+	if client, err = NewClient(config, router); err != nil {
 		t.Errorf("cannot create XMPP client: %s", err)
 	}
 
@@ -71,7 +73,8 @@ func TestClient_FeaturesTracking(t *testing.T) {
 
 	var client *Client
 	var err error
-	if client, err = NewClient(config); err != nil {
+	router := NewRouter()
+	if client, err = NewClient(config, router); err != nil {
 		t.Errorf("cannot create XMPP client: %s", err)
 	}
 

--- a/component.go
+++ b/component.go
@@ -224,9 +224,9 @@ func (handshakeDecoder) decode(p *xml.Decoder, se xml.StartElement) (Handshake, 
 // depending on the context.
 type Delegation struct {
 	MsgExtension
-	XMLName   xml.Name  `xml:"urn:xmpp:delegation:1 delegation"`
-	Forwarded Forwarded // This is used in iq to wrap delegated iqs
-	Delegated Delegated // This is used in a message to confirm delegated namespace
+	XMLName   xml.Name   `xml:"urn:xmpp:delegation:1 delegation"`
+	Forwarded *Forwarded // This is used in iq to wrap delegated iqs
+	Delegated *Delegated // This is used in a message to confirm delegated namespace
 }
 
 func (d *Delegation) Namespace() string {
@@ -234,10 +234,33 @@ func (d *Delegation) Namespace() string {
 }
 
 type Forwarded struct {
-	XMLName  xml.Name `xml:"urn:xmpp:forward:0 forwarded"`
-	IQ       IQ
-	Message  Message
-	Presence Presence
+	XMLName xml.Name `xml:"urn:xmpp:forward:0 forwarded"`
+	Stanza  Packet
+}
+
+// UnmarshalXML is a custom unmarshal function used by xml.Unmarshal to
+// transform generic XML content into hierarchical Node structure.
+func (f *Forwarded) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	// Check subelements to extract required field as boolean
+	for {
+		t, err := d.Token()
+		if err != nil {
+			return err
+		}
+
+		switch tt := t.(type) {
+
+		case xml.StartElement:
+			if packet, err := decodeClient(d, tt); err == nil {
+				f.Stanza = packet
+			}
+
+		case xml.EndElement:
+			if tt == start.End() {
+				return nil
+			}
+		}
+	}
 }
 
 type Delegated struct {

--- a/component.go
+++ b/component.go
@@ -37,8 +37,6 @@ type ComponentOptions struct {
 	// =================================
 	// Communication with developer client / StreamManager
 
-	// Packet channel
-	RecvChannel chan Packet
 	// Track and broadcast connection state
 	EventManager
 }
@@ -60,8 +58,6 @@ type Component struct {
 
 func NewComponent(opts ComponentOptions, r *Router) (*Component, error) {
 	c := Component{ComponentOptions: opts, router: r}
-	// Create a default channel that developers can override
-	c.RecvChannel = make(chan Packet)
 	return &c, nil
 }
 

--- a/component.go
+++ b/component.go
@@ -120,15 +120,6 @@ func (c *Component) SetHandler(handler EventHandler) {
 	c.Handler = handler
 }
 
-// Recv abstracts receiving preparsed XMPP packets from a channel.
-// Channel allow client to receive / dispatch packets in for range loop.
-// TODO: Deprecate this function in favor of reading directly from the RecvChannel ?
-/*
-func (c *Component) Recv() <-chan Packet {
-	return c.RecvChannel
-}
-*/
-
 // Receiver Go routine receiver
 func (c *Component) recv() (err error) {
 	for {

--- a/component.go
+++ b/component.go
@@ -141,11 +141,11 @@ func (c *Component) recv() (err error) {
 		// Handle stream errors
 		switch p := val.(type) {
 		case StreamError:
-			c.router.Route(c.conn, val)
+			c.router.Route(c, val)
 			c.streamError(p.Error.Local, p.Text)
 			return errors.New("stream error: " + p.Error.Local)
 		}
-		c.router.Route(c.conn, val)
+		c.router.Route(c, val)
 	}
 }
 

--- a/component_test.go
+++ b/component_test.go
@@ -1,6 +1,9 @@
 package xmpp // import "gosrc.io/xmpp"
 
-import "testing"
+import (
+	"encoding/xml"
+	"testing"
+)
 
 func TestHandshake(t *testing.T) {
 	opts := ComponentOptions{
@@ -20,4 +23,73 @@ func TestHandshake(t *testing.T) {
 
 func TestGenerateHandshake(t *testing.T) {
 	// TODO
+}
+
+// We should be able to properly parse delegation confirmation messages
+func TestParsingDelegationMessage(t *testing.T) {
+	packetStr := `<message to='service.localhost' from='localhost'>
+ <delegation xmlns='urn:xmpp:delegation:1'>
+  <delegated namespace='http://jabber.org/protocol/pubsub'/>
+ </delegation>
+</message>`
+	var msg Message
+	data := []byte(packetStr)
+	if err := xml.Unmarshal(data, &msg); err != nil {
+		t.Errorf("Unmarshal(%s) returned error", data)
+	}
+
+	// Check that we have extracted the delegation info as MsgExtension
+	var nsDelegated string
+	for _, ext := range msg.Extensions {
+		if delegation, ok := ext.(*Delegation); ok {
+			nsDelegated = delegation.Delegated.Namespace
+		}
+	}
+	if nsDelegated != "http://jabber.org/protocol/pubsub" {
+		t.Errorf("Could not find delegated namespace in delegation: %#v\n", msg)
+	}
+}
+
+// Check that we can parse a delegation IQ.
+// The most important thing is to be able to
+func TestParsingDelegationIQ(t *testing.T) {
+	packetStr := `<iq to='service.localhost' from='localhost' type='set' id='1'>
+ <delegation xmlns='urn:xmpp:delegation:1'>
+  <forwarded xmlns='urn:xmpp:forward:0'>
+   <iq xml:lang='en' to='test1@localhost' from='test1@localhost/mremond-mbp' type='set' id='aaf3a' xmlns='jabber:client'>
+    <pubsub xmlns='http://jabber.org/protocol/pubsub'>
+     <publish node='http://jabber.org/protocol/mood'>
+      <item id='current'>
+       <mood xmlns='http://jabber.org/protocol/mood'>
+        <excited/>
+       </mood>
+      </item>
+     </publish>
+    </pubsub>
+   </iq>
+  </forwarded>
+ </delegation>
+</iq>`
+	var iq IQ
+	data := []byte(packetStr)
+	if err := xml.Unmarshal(data, &iq); err != nil {
+		t.Errorf("Unmarshal(%s) returned error", data)
+	}
+
+	// Check that we have extracted the delegation info as IQPayload
+	var node string
+	for _, ext := range iq.Payload {
+		if delegation, ok := ext.(*Delegation); ok {
+			payload := delegation.Forwarded.IQ.Payload
+			if len(payload) > 0 {
+				payload := delegation.Forwarded.IQ.Payload[0]
+				if pubsub, ok := payload.(*PubSub); ok {
+					node = pubsub.Publish.Node
+				}
+			}
+		}
+	}
+	if node != "http://jabber.org/protocol/mood" {
+		t.Errorf("Could not find mood node name on delegated publish: %#v\n", iq)
+	}
 }

--- a/component_test.go
+++ b/component_test.go
@@ -80,10 +80,16 @@ func TestParsingDelegationIQ(t *testing.T) {
 	var node string
 	for _, ext := range iq.Payload {
 		if delegation, ok := ext.(*Delegation); ok {
-			payload := delegation.Forwarded.IQ.Payload
+			packet := delegation.Forwarded.Stanza
+			forwardedIQ, ok := packet.(IQ)
+			if !ok {
+				t.Errorf("Could not extract packet IQ")
+				return
+			}
+			payload := forwardedIQ.Payload
 			if len(payload) > 0 {
-				payload := delegation.Forwarded.IQ.Payload[0]
-				if pubsub, ok := payload.(*PubSub); ok {
+				pl := payload[0]
+				if pubsub, ok := pl.(*PubSub); ok {
 					node = pubsub.Publish.Node
 				}
 			}

--- a/iot_control.go
+++ b/iot_control.go
@@ -5,9 +5,12 @@ import (
 )
 
 type ControlSet struct {
-	IQPayload
 	XMLName xml.Name       `xml:"urn:xmpp:iot:control set"`
 	Fields  []ControlField `xml:",any"`
+}
+
+func (c *ControlSet) Namespace() string {
+	return c.XMLName.Space
 }
 
 type ControlGetForm struct {
@@ -23,4 +26,8 @@ type ControlField struct {
 type ControlSetResponse struct {
 	IQPayload
 	XMLName xml.Name `xml:"urn:xmpp:iot:control setResponse"`
+}
+
+func (c *ControlSetResponse) Namespace() string {
+	return c.XMLName.Space
 }

--- a/iq.go
+++ b/iq.go
@@ -16,12 +16,15 @@ TODO support ability to put Raw payload inside IQ
 // presence or iq stanza.
 // It is intended to be added in the payload of the erroneous stanza.
 type Err struct {
-	IQPayload
 	XMLName xml.Name `xml:"error"`
 	Code    int      `xml:"code,attr,omitempty"`
 	Type    string   `xml:"type,attr,omitempty"`
 	Reason  string
 	Text    string `xml:"urn:ietf:params:xml:ns:xmpp-stanzas text,omitempty"`
+}
+
+func (x *Err) Namespace() string {
+	return x.XMLName.Space
 }
 
 // UnmarshalXML implements custom parsing for IQs
@@ -120,6 +123,10 @@ func (x Err) MarshalXML(e *xml.Encoder, start xml.StartElement) (err error) {
 type IQ struct { // Info/Query
 	XMLName xml.Name `xml:"iq"`
 	PacketAttrs
+	// FIXME: We can only have one payload:
+	//   "An IQ stanza of type "get" or "set" MUST contain exactly one
+	//    child element, which specifies the semantics of the particular
+	//    request."
 	Payload []IQPayload `xml:",omitempty"`
 	RawXML  string      `xml:",innerxml"`
 	Error   Err         `xml:"error,omitempty"`
@@ -229,16 +236,21 @@ func (iq *IQ) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 // ============================================================================
 // Generic IQ Payload
 
-type IQPayload interface{}
+type IQPayload interface {
+	Namespace() string
+}
 
 // Node is a generic structure to represent XML data. It is used to parse
 // unreferenced or custom stanza payload.
 type Node struct {
-	IQPayload
 	XMLName xml.Name
 	Attrs   []xml.Attr `xml:"-"`
 	Content string     `xml:",innerxml"`
 	Nodes   []Node     `xml:",any"`
+}
+
+func (n *Node) Namespace() string {
+	return n.XMLName.Space
 }
 
 // Attr represents generic XML attributes, as used on the generic XML Node
@@ -283,11 +295,14 @@ const (
 
 // Disco Info
 type DiscoInfo struct {
-	IQPayload
 	XMLName  xml.Name  `xml:"http://jabber.org/protocol/disco#info query"`
 	Node     string    `xml:"node,attr,omitempty"`
 	Identity Identity  `xml:"identity"`
 	Features []Feature `xml:"feature"`
+}
+
+func (d *DiscoInfo) Namespace() string {
+	return d.XMLName.Space
 }
 
 type Identity struct {
@@ -304,10 +319,13 @@ type Feature struct {
 
 // Disco Items
 type DiscoItems struct {
-	IQPayload
 	XMLName xml.Name    `xml:"http://jabber.org/protocol/disco#items query"`
 	Node    string      `xml:"node,attr,omitempty"`
 	Items   []DiscoItem `xml:"item"`
+}
+
+func (d *DiscoItems) Namespace() string {
+	return d.XMLName.Space
 }
 
 type DiscoItem struct {
@@ -322,11 +340,14 @@ type DiscoItem struct {
 
 // Version
 type Version struct {
-	IQPayload
 	XMLName xml.Name `xml:"jabber:iq:version query"`
 	Name    string   `xml:"name,omitempty"`
 	Version string   `xml:"version,omitempty"`
 	OS      string   `xml:"os,omitempty"`
+}
+
+func (v *Version) Namespace() string {
+	return v.XMLName.Space
 }
 
 // ============================================================================

--- a/iq_test.go
+++ b/iq_test.go
@@ -1,4 +1,4 @@
-package xmpp_test // import "gosrc.io/xmpp_test"
+package xmpp_test
 
 import (
 	"encoding/xml"

--- a/pep.go
+++ b/pep.go
@@ -1,24 +1,10 @@
 package xmpp // import "gosrc.io/xmpp"
 
+// TODO: Move to a pubsub file
+
 import (
 	"encoding/xml"
 )
-
-type PubSub struct {
-	XMLName xml.Name `xml:"http://jabber.org/protocol/pubsub pubsub"`
-	Publish Publish
-}
-
-type Publish struct {
-	XMLName xml.Name `xml:"publish"`
-	Node    string   `xml:"node,attr"`
-	Item    Item
-}
-
-type Item struct {
-	XMLName xml.Name `xml:"item"`
-	Tune    Tune
-}
 
 type Tune struct {
 	XMLName xml.Name `xml:"http://jabber.org/protocol/tune tune"`
@@ -31,53 +17,9 @@ type Tune struct {
 	Uri     string   `xml:"uri,omitempty"`
 }
 
-/*
-type PubsubPublish struct {
-	XMLName xml.Name `xml:"publish"`
-	node    string   `xml:"node,attr"`
-	item    PubSubItem
+type Mood struct {
+	XMLName xml.Name `xml:"http://jabber.org/protocol/mood mood"`
+	// TODO: Custom parsing to extract mood type from tag name
+	// Mood type
+	Text string `xml:"text,omitempty"`
 }
-
-type PubSubItem struct {
-	xmlName xml.Name `xml:"item"`
-}
-
-type Thing2 struct {
-	XMLName xml.Name `xml:"publish"`
-	node    string   `xml:"node,attr"`
-	tune    string   `xml:"http://jabber.org/protocol/tune item>tune"`
-}
-
-type Tune struct {
-	artist string
-	length int
-	rating int
-	source string
-	title  string
-	track  string
-	uri    string
-}
-*/
-
-/*
-func (*Tune) XMPPFormat() string {
-	return fmt.Sprintf(
-		`<iq type='set' id='%s'>
- <pubsub xmlns='http://jabber.org/protocol/pubsub'>
-  <publish node='http://jabber.org/protocol/tune'>
-   <item>
-    <tune xmlns='http://jabber.org/protocol/tune'>
-     <artist>%s</artist>
-     <length>%i</length>
-     <rating>%i</rating>
-     <source>%s</source>
-     <title>%s</title>
-     <track>%s</track>
-     <uri>%s</uri>
-    </tune>
-   </item>
-  </publish>
- </pubsub>
-</iq>`)
-}
-*/

--- a/pep.go
+++ b/pep.go
@@ -17,9 +17,13 @@ type Tune struct {
 	Uri     string   `xml:"uri,omitempty"`
 }
 
+// Mood defines deta model for XEP-0107 - User Mood
+// See: https://xmpp.org/extensions/xep-0107.html
 type Mood struct {
-	XMLName xml.Name `xml:"http://jabber.org/protocol/mood mood"`
-	// TODO: Custom parsing to extract mood type from tag name
+	MsgExtension          // Mood can be added as a message extension
+	XMLName      xml.Name `xml:"http://jabber.org/protocol/mood mood"`
+	// TODO: Custom parsing to extract mood type from tag name.
+	// Note: the list is predefined.
 	// Mood type
 	Text string `xml:"text,omitempty"`
 }

--- a/pubsub.go
+++ b/pubsub.go
@@ -6,8 +6,8 @@ import (
 
 type PubSub struct {
 	XMLName xml.Name `xml:"http://jabber.org/protocol/pubsub pubsub"`
-	Publish Publish
-	Retract Retract
+	Publish *Publish
+	Retract *Retract
 	// TODO <configure/>
 }
 
@@ -24,7 +24,8 @@ type Publish struct {
 type Item struct {
 	XMLName xml.Name `xml:"item"`
 	Id      string   `xml:"id,attr,omitempty"`
-	Tune    Tune
+	Tune    *Tune
+	Mood    *Mood
 }
 
 type Retract struct {

--- a/pubsub.go
+++ b/pubsub.go
@@ -1,0 +1,39 @@
+package xmpp // import "gosrc.io/xmpp"
+
+import (
+	"encoding/xml"
+)
+
+type PubSub struct {
+	XMLName xml.Name `xml:"http://jabber.org/protocol/pubsub pubsub"`
+	Publish Publish
+	Retract Retract
+	// TODO <configure/>
+}
+
+func (p *PubSub) Namespace() string {
+	return p.XMLName.Space
+}
+
+type Publish struct {
+	XMLName xml.Name `xml:"publish"`
+	Node    string   `xml:"node,attr"`
+	Item    Item
+}
+
+type Item struct {
+	XMLName xml.Name `xml:"item"`
+	Id      string   `xml:"id,attr,omitempty"`
+	Tune    Tune
+}
+
+type Retract struct {
+	XMLName xml.Name `xml:"retract"`
+	Node    string   `xml:"node,attr"`
+	Notify  string   `xml:"notify,attr"`
+	Item    Item
+}
+
+func init() {
+	TypeRegistry.MapExtension(PKTIQ, xml.Name{"http://jabber.org/protocol/pubsub", "pubsub"}, PubSub{})
+}

--- a/router.go
+++ b/router.go
@@ -1,0 +1,193 @@
+package xmpp
+
+import (
+	"io"
+	"strings"
+)
+
+/*
+The XMPP router helps client and component developer select which XMPP they would like to process,
+and associate processing code depending on the router configuration.
+
+TODO: Automatically reply to IQ that do not match any route, to comply to XMPP standard.
+*/
+
+type Router struct {
+	// Routes to be matched, in order.
+	routes []*Route
+}
+
+// NewRouter returns a new router instance.
+func NewRouter() *Router {
+	return &Router{}
+}
+
+func (r *Router) Route(w io.Writer, p Packet) {
+	var match RouteMatch
+	if r.Match(p, &match) {
+		match.Handler.HandlePacket(w, p)
+	}
+}
+
+// NewRoute registers an empty routes
+func (r *Router) NewRoute() *Route {
+	route := &Route{}
+	r.routes = append(r.routes, route)
+	return route
+}
+
+func (r *Router) Match(p Packet, match *RouteMatch) bool {
+	for _, route := range r.routes {
+		if route.Match(p, match) {
+			return true
+		}
+	}
+	return false
+}
+
+// Handle registers a new route with a matcher for a given packet name (iq, message, presence)
+// See Route.Packet() and Route.Handler().
+func (r *Router) Handle(name string, handler Handler) *Route {
+	return r.NewRoute().Packet(name).Handler(handler)
+}
+
+// HandleFunc registers a new route with a matcher for for a given packet name (iq, message, presence)
+// See Route.Path() and Route.HandlerFunc().
+func (r *Router) HandleFunc(name string, f func(io.Writer, Packet)) *Route {
+	return r.NewRoute().Packet(name).HandlerFunc(f)
+}
+
+// ============================================================================
+// Route
+type Handler interface {
+	HandlePacket(w io.Writer, p Packet)
+}
+
+type Route struct {
+	handler Handler
+	// Matchers are used to "specialize" routes and focus on specific packet features
+	matchers []matcher
+}
+
+func (r *Route) Handler(handler Handler) *Route {
+	r.handler = handler
+	return r
+}
+
+// The HandlerFunc type is an adapter to allow the use of
+// ordinary functions as XMPP handlers. If f is a function
+// with the appropriate signature, HandlerFunc(f) is a
+// Handler that calls f.
+type HandlerFunc func(io.Writer, Packet)
+
+// HandlePacket calls f(w, p)
+func (f HandlerFunc) HandlePacket(w io.Writer, p Packet) {
+	f(w, p)
+}
+
+// HandlerFunc sets a handler function for the route
+func (r *Route) HandlerFunc(f HandlerFunc) *Route {
+	return r.Handler(f)
+}
+
+// addMatcher adds a matcher to the route
+func (r *Route) addMatcher(m matcher) *Route {
+	r.matchers = append(r.matchers, m)
+	return r
+}
+
+func (r *Route) Match(p Packet, match *RouteMatch) bool {
+	for _, m := range r.matchers {
+		if matched := m.Match(p, match); !matched {
+			return false
+		}
+	}
+
+	// We have a match, let's pass info route match info
+	match.Route = r
+	match.Handler = r.handler
+	return true
+}
+
+// --------------------
+// Match on packet name
+
+type nameMatcher string
+
+func (n nameMatcher) Match(p Packet, match *RouteMatch) bool {
+	var name string
+	// TODO: To avoid type switch everywhere in matching, I think we will need to have
+	//    to move to a concrete type for packets, to make matching and comparison more natural.
+	//    Current code structure is probably too rigid.
+	// Maybe packet types should even be from an enum.
+	switch p.(type) {
+	case Message:
+		name = "message"
+	case IQ:
+		name = "iq"
+	case Presence:
+		name = "presence"
+	}
+	if name == string(n) {
+		return true
+	}
+	return false
+}
+
+// Packet matches on a packet name (iq, message, presence, ...)
+// It matches on the Local part of the xml.Name
+func (r *Route) Packet(name string) *Route {
+	name = strings.ToLower(name)
+	return r.addMatcher(nameMatcher(name))
+}
+
+// -------------------------
+// Match on IQ and namespace
+
+// nsIqMather matches on a list of IQ  payload namespaces
+type nsIQMatcher []string
+
+func (m nsIQMatcher) Match(p Packet, match *RouteMatch) bool {
+	// TODO
+	iq, ok := p.(IQ)
+	if !ok {
+		return false
+	}
+	if len(iq.Payload) < 1 {
+		return false
+	}
+	return matchInArray(m, iq.Payload[0].Namespace())
+}
+
+// IQNamespaces adds an IQ matcher, expecting both an IQ and a
+func (r *Route) IQNamespaces(namespaces ...string) *Route {
+	for k, v := range namespaces {
+		namespaces[k] = strings.ToLower(v)
+	}
+	return r.addMatcher(nsIQMatcher(namespaces))
+}
+
+// ============================================================================
+// Matchers
+
+// Matchers are used to "specialize" routes and focus on specific packet features
+type matcher interface {
+	Match(Packet, *RouteMatch) bool
+}
+
+// RouteMatch extracts and gather match information
+type RouteMatch struct {
+	Route   *Route
+	Handler Handler
+}
+
+// matchInArray is a generic matching function to check if a string is a list
+// of specific function
+func matchInArray(arr []string, value string) bool {
+	for _, str := range arr {
+		if str == value {
+			return true
+		}
+	}
+	return false
+}

--- a/router.go
+++ b/router.go
@@ -8,6 +8,11 @@ import (
 The XMPP router helps client and component developers select which XMPP they would like to process,
 and associate processing code depending on the router configuration.
 
+Here are important rules to keep in mind while setting your routes and matchers:
+- Routes are evaluated in the order they are set.
+- When a route matches, it is executed and all others routes are ignored. For each packet, only a single
+  route is executed.
+
 TODO: Automatically reply to IQ that do not match any route, to comply to XMPP standard.
 */
 

--- a/router.go
+++ b/router.go
@@ -1,12 +1,11 @@
 package xmpp
 
 import (
-	"io"
 	"strings"
 )
 
 /*
-The XMPP router helps client and component developer select which XMPP they would like to process,
+The XMPP router helps client and component developers select which XMPP they would like to process,
 and associate processing code depending on the router configuration.
 
 TODO: Automatically reply to IQ that do not match any route, to comply to XMPP standard.
@@ -22,10 +21,10 @@ func NewRouter() *Router {
 	return &Router{}
 }
 
-func (r *Router) Route(w io.Writer, p Packet) {
+func (r *Router) Route(s Sender, p Packet) {
 	var match RouteMatch
 	if r.Match(p, &match) {
-		match.Handler.HandlePacket(w, p)
+		match.Handler.HandlePacket(s, p)
 	}
 }
 
@@ -53,14 +52,14 @@ func (r *Router) Handle(name string, handler Handler) *Route {
 
 // HandleFunc registers a new route with a matcher for for a given packet name (iq, message, presence)
 // See Route.Path() and Route.HandlerFunc().
-func (r *Router) HandleFunc(name string, f func(io.Writer, Packet)) *Route {
+func (r *Router) HandleFunc(name string, f func(s Sender, p Packet)) *Route {
 	return r.NewRoute().Packet(name).HandlerFunc(f)
 }
 
 // ============================================================================
 // Route
 type Handler interface {
-	HandlePacket(w io.Writer, p Packet)
+	HandlePacket(s Sender, p Packet)
 }
 
 type Route struct {
@@ -78,11 +77,11 @@ func (r *Route) Handler(handler Handler) *Route {
 // ordinary functions as XMPP handlers. If f is a function
 // with the appropriate signature, HandlerFunc(f) is a
 // Handler that calls f.
-type HandlerFunc func(io.Writer, Packet)
+type HandlerFunc func(s Sender, p Packet)
 
-// HandlePacket calls f(w, p)
-func (f HandlerFunc) HandlePacket(w io.Writer, p Packet) {
-	f(w, p)
+// HandlePacket calls f(s, p)
+func (f HandlerFunc) HandlePacket(s Sender, p Packet) {
+	f(s, p)
 }
 
 // HandlerFunc sets a handler function for the route

--- a/router_test.go
+++ b/router_test.go
@@ -1,0 +1,75 @@
+package xmpp_test
+
+import (
+	"bytes"
+	"encoding/xml"
+	"io"
+	"testing"
+
+	"gosrc.io/xmpp"
+)
+
+var successFlag = []byte("matched")
+
+func TestNameMatcher(t *testing.T) {
+	router := xmpp.NewRouter()
+	router.HandleFunc("message", func(w io.Writer, p xmpp.Packet) {
+		_, _ = w.Write(successFlag)
+	})
+
+	// Check that a message packet is properly matched
+	var buf bytes.Buffer
+	// TODO: We want packet creation code to use struct to use default values
+	msg := xmpp.NewMessage("chat", "", "test@localhost", "1", "")
+	msg.Body = "Hello"
+	router.Route(&buf, msg)
+	if !bytes.Equal(buf.Bytes(), successFlag) {
+		t.Error("Message was not matched and routed properly")
+	}
+
+	// Check that an IQ packet is not matched
+	buf = bytes.Buffer{}
+	iq := xmpp.NewIQ("get", "", "localhost", "1", "")
+	iq.Payload = append(iq.Payload, &xmpp.DiscoInfo{})
+	router.Route(&buf, iq)
+	if bytes.Equal(buf.Bytes(), successFlag) {
+		t.Error("IQ should not have been matched and routed")
+	}
+}
+
+func TestIQNSMatcher(t *testing.T) {
+	router := xmpp.NewRouter()
+	router.NewRoute().
+		IQNamespaces(xmpp.NSDiscoInfo, xmpp.NSDiscoItems).
+		HandlerFunc(func(w io.Writer, p xmpp.Packet) {
+			_, _ = w.Write(successFlag)
+		})
+
+	// Check that an IQ with proper namespace does match
+	var buf bytes.Buffer
+	iqDisco := xmpp.NewIQ("get", "", "localhost", "1", "")
+	// TODO: Add a function to generate payload with proper namespace initialisation
+	iqDisco.Payload = append(iqDisco.Payload, &xmpp.DiscoInfo{
+		XMLName: xml.Name{
+			Space: xmpp.NSDiscoInfo,
+			Local: "query",
+		}})
+	router.Route(&buf, iqDisco)
+	if !bytes.Equal(buf.Bytes(), successFlag) {
+		t.Errorf("IQ should have been matched and routed: %v", iqDisco)
+	}
+
+	// Check that another namespace is not matched
+	buf = bytes.Buffer{}
+	iqVersion := xmpp.NewIQ("get", "", "localhost", "1", "")
+	// TODO: Add a function to generate payload with proper namespace initialisation
+	iqVersion.Payload = append(iqVersion.Payload, &xmpp.DiscoInfo{
+		XMLName: xml.Name{
+			Space: "jabber:iq:version",
+			Local: "query",
+		}})
+	router.Route(&buf, iqVersion)
+	if bytes.Equal(buf.Bytes(), successFlag) {
+		t.Errorf("IQ should not have been matched and routed: %v", iqVersion)
+	}
+}

--- a/stream.go
+++ b/stream.go
@@ -6,7 +6,9 @@ import (
 
 // ============================================================================
 // StreamFeatures Packet
-// Reference: https://xmpp.org/registrar/stream-features.html
+// Reference: The active stream features are published on
+//            https://xmpp.org/registrar/stream-features.html
+// Note: That page misses draft and experimental XEP (i.e CSI, etc)
 
 type StreamFeatures struct {
 	XMLName xml.Name `xml:"http://etherx.jabber.org/streams features"`

--- a/stream_manager.go
+++ b/stream_manager.go
@@ -19,10 +19,18 @@ import (
 //       permanent errors to avoid useless reconnection loops.
 //     - Metrics processing
 
+// StreamClient is an interface used by StreamManager to control Client lifecycle,
+// set callback and trigger reconnection.
 type StreamClient interface {
 	Connect() error
 	Disconnect()
 	SetHandler(handler EventHandler)
+}
+
+// Sender is an interface provided by Stream clients to allow sending XMPP data.
+type Sender interface {
+	Send(packet Packet) error
+	SendRaw(packet string) error
 }
 
 // StreamManager supervises an XMPP client connection. Its role is to handle connection events and


### PR DESCRIPTION
- Add basic support for Router to make it easier to get your code trigger when some packets are received.
- Add initial support for namespace delegation (XEP-0355) and priviledged entities (XEP-0356) and example component.
- Clean up un IQ structures.