### PR TITLE
muc history of zero stanzes are not supported

### DIFF
--- a/error.go
+++ b/error.go
@@ -27,7 +27,7 @@ func (x *Err) Namespace() string {
 	return x.XMLName.Space
 }
 
-// UnmarshalXML implements custom parsing for IQs
+// UnmarshalXML implements custom parsing for XMPP errors
 func (x *Err) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	x.XMLName = start.Name
 

--- a/pres_muc.go
+++ b/pres_muc.go
@@ -18,10 +18,10 @@ type MucPresence struct {
 
 // History implements XEP-0045: Multi-User Chat - 19.1
 type History struct {
-	MaxChars   int       `xml:"maxchars,attr,omitempty"`
-	MaxStanzas int       `xml:"maxstanzas,attr,omitempty"`
-	Seconds    int       `xml:"seconds,attr,omitempty"`
-	Since      time.Time `xml:"since,attr,omitempty"`
+	MaxChars   *int       `xml:"maxchars,attr,omitempty"`
+	MaxStanzas *int       `xml:"maxstanzas,attr,omitempty"`
+	Seconds    *int       `xml:"seconds,attr,omitempty"`
+	Since      *time.Time `xml:"since,attr,omitempty"`
 }
 
 func init() {

--- a/pres_muc.go
+++ b/pres_muc.go
@@ -2,6 +2,7 @@ package xmpp
 
 import (
 	"encoding/xml"
+	"strconv"
 	"time"
 )
 
@@ -16,12 +17,130 @@ type MucPresence struct {
 	History  History  `xml:"history,omitempty"`
 }
 
+const timeLayout = "2006-01-02T15:04:05Z"
+
 // History implements XEP-0045: Multi-User Chat - 19.1
 type History struct {
-	MaxChars   *int       `xml:"maxchars,attr,omitempty"`
-	MaxStanzas *int       `xml:"maxstanzas,attr,omitempty"`
-	Seconds    *int       `xml:"seconds,attr,omitempty"`
-	Since      *time.Time `xml:"since,attr,omitempty"`
+	XMLName    xml.Name
+	MaxChars   NullableInt `xml:"maxchars,attr,omitempty"`
+	MaxStanzas NullableInt `xml:"maxstanzas,attr,omitempty"`
+	Seconds    NullableInt `xml:"seconds,attr,omitempty"`
+	Since      time.Time   `xml:"since,attr,omitempty"`
+}
+
+type NullableInt struct {
+	Value int
+	isSet bool
+}
+
+func NewNullableInt(val int) NullableInt {
+	return NullableInt{val, true}
+}
+
+func (n NullableInt) Get() (v int, ok bool) {
+	return n.Value, n.isSet
+}
+
+// UnmarshalXML implements custom parsing for history element
+func (h *History) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	h.XMLName = start.Name
+
+	// Extract attributes
+	for _, attr := range start.Attr {
+		switch attr.Name.Local {
+		case "maxchars":
+			v, err := strconv.Atoi(attr.Value)
+			if err != nil {
+				return err
+			}
+			h.MaxChars = NewNullableInt(v)
+		case "maxstanzas":
+			v, err := strconv.Atoi(attr.Value)
+			if err != nil {
+				return err
+			}
+			h.MaxStanzas = NewNullableInt(v)
+		case "seconds":
+			v, err := strconv.Atoi(attr.Value)
+			if err != nil {
+				return err
+			}
+			h.Seconds = NewNullableInt(v)
+		case "since":
+			t, err := time.Parse(timeLayout, attr.Value)
+			if err != nil {
+				return err
+			}
+			h.Since = t
+		}
+	}
+
+	// Consume remaining data until element end
+	for {
+		t, err := d.Token()
+		if err != nil {
+			return err
+		}
+
+		switch tt := t.(type) {
+		case xml.EndElement:
+			if tt == start.End() {
+				return nil
+			}
+		}
+	}
+}
+
+func (h History) MarshalXML(e *xml.Encoder, start xml.StartElement) (err error) {
+	mc, isMcSet := h.MaxChars.Get()
+	ms, isMsSet := h.MaxStanzas.Get()
+	s, isSSet := h.Seconds.Get()
+
+	// We do not have any value, ignore history element
+	if h.Since.IsZero() && !isMcSet && !isMsSet && !isSSet {
+		return nil
+	}
+
+	// Encode start element and attributes
+	start.Name = xml.Name{Local: "history"}
+
+	if isMcSet {
+		attr := xml.Attr{
+			Name:  xml.Name{Local: "maxchars"},
+			Value: strconv.Itoa(mc),
+		}
+		start.Attr = append(start.Attr, attr)
+	}
+
+	if isMsSet {
+		attr := xml.Attr{
+			Name:  xml.Name{Local: "maxstanzas"},
+			Value: strconv.Itoa(ms),
+		}
+		start.Attr = append(start.Attr, attr)
+	}
+
+	if isSSet {
+		attr := xml.Attr{
+			Name:  xml.Name{Local: "seconds"},
+			Value: strconv.Itoa(s),
+		}
+		start.Attr = append(start.Attr, attr)
+	}
+
+	if !h.Since.IsZero() {
+		attr := xml.Attr{
+			Name:  xml.Name{Local: "since"},
+			Value: h.Since.Format(timeLayout),
+		}
+		start.Attr = append(start.Attr, attr)
+	}
+	if err := e.EncodeToken(start); err != nil {
+		return err
+	}
+
+	return e.EncodeToken(xml.EndElement{Name: start.Name})
+
 }
 
 func init() {

--- a/pres_muc_test.go
+++ b/pres_muc_test.go
@@ -54,30 +54,32 @@ func TestMucHistory(t *testing.T) {
 		t.Error("muc presence extension was not found")
 	}
 
-	if muc.History.MaxStanzas != 20 {
+	if *muc.History.MaxStanzas != 20 {
 		t.Errorf("incorrect max stanza: '%d'", muc.History.MaxStanzas)
 	}
 }
 
 // https://xmpp.org/extensions/xep-0045.html#example-37
 func TestMucNoHistory(t *testing.T) {
-	str := `<presence
-    from='hag66@shakespeare.lit/pda'
-    id='n13mt3l'
-    to='coven@chat.shakespeare.lit/thirdwitch'>
-  <x xmlns='http://jabber.org/protocol/muc'>
-    <history maxstanzas='0'/>
-  </x>
-</presence>`
+	str := "<presence" +
+		" id=\"n13mt3l\"" +
+		" from=\"hag66@shakespeare.lit/pda\"" +
+		" to=\"coven@chat.shakespeare.lit/thirdwitch\">" +
+		"<x xmlns=\"http://jabber.org/protocol/muc\">" +
+		"<history maxstanzas=\"0\"></history>" +
+		"</x>" +
+		"</presence>"
+
+	maxstanzas := 0
 
 	pres := xmpp.Presence{Attrs: xmpp.Attrs{
-			From: "hag66@shakespeare.lit/pda",
-			Id: "n13mt3l",
-			To: "coven@chat.shakespeare.lit/thirdwitch",
-		},
+		From: "hag66@shakespeare.lit/pda",
+		Id:   "n13mt3l",
+		To:   "coven@chat.shakespeare.lit/thirdwitch",
+	},
 		Extensions: []xmpp.PresExtension{
 			xmpp.MucPresence{
-				History: xmpp.History{MaxStanzas: 0},
+				History: xmpp.History{MaxStanzas: &maxstanzas},
 			},
 		},
 	}
@@ -86,7 +88,7 @@ func TestMucNoHistory(t *testing.T) {
 		t.Error("error on encode:", err)
 	}
 
-	if data != str {
-		t.Errorf("incorrect max stanza: '%d'", muc.History.MaxStanzas)
+	if string(data) != str {
+		t.Errorf("incorrect stanza: \n%s\n%s", str, data)
 	}
 }

--- a/pres_muc_test.go
+++ b/pres_muc_test.go
@@ -46,16 +46,18 @@ func TestMucHistory(t *testing.T) {
 
 	var parsedPresence xmpp.Presence
 	if err := xml.Unmarshal([]byte(str), &parsedPresence); err != nil {
-		t.Errorf("Unmarshal(%s) returned error", str)
+		t.Errorf("Unmarshal(%s) returned error: %s", str, err)
+		return
 	}
 
 	var muc xmpp.MucPresence
 	if ok := parsedPresence.Get(&muc); !ok {
 		t.Error("muc presence extension was not found")
+		return
 	}
 
-	if *muc.History.MaxStanzas != 20 {
-		t.Errorf("incorrect max stanza: '%d'", muc.History.MaxStanzas)
+	if v, ok := muc.History.MaxStanzas.Get(); !ok || v != 20 {
+		t.Errorf("incorrect MaxStanzas: '%#v'", muc.History.MaxStanzas)
 	}
 }
 
@@ -79,13 +81,14 @@ func TestMucNoHistory(t *testing.T) {
 	},
 		Extensions: []xmpp.PresExtension{
 			xmpp.MucPresence{
-				History: xmpp.History{MaxStanzas: &maxstanzas},
+				History: xmpp.History{MaxStanzas: xmpp.NewNullableInt(maxstanzas)},
 			},
 		},
 	}
 	data, err := xml.Marshal(&pres)
 	if err != nil {
 		t.Error("error on encode:", err)
+		return
 	}
 
 	if string(data) != str {

--- a/pres_muc_test.go
+++ b/pres_muc_test.go
@@ -58,3 +58,35 @@ func TestMucHistory(t *testing.T) {
 		t.Errorf("incorrect max stanza: '%d'", muc.History.MaxStanzas)
 	}
 }
+
+// https://xmpp.org/extensions/xep-0045.html#example-37
+func TestMucNoHistory(t *testing.T) {
+	str := `<presence
+    from='hag66@shakespeare.lit/pda'
+    id='n13mt3l'
+    to='coven@chat.shakespeare.lit/thirdwitch'>
+  <x xmlns='http://jabber.org/protocol/muc'>
+    <history maxstanzas='0'/>
+  </x>
+</presence>`
+
+	pres := xmpp.Presence{Attrs: xmpp.Attrs{
+			From: "hag66@shakespeare.lit/pda",
+			Id: "n13mt3l",
+			To: "coven@chat.shakespeare.lit/thirdwitch",
+		},
+		Extensions: []xmpp.PresExtension{
+			xmpp.MucPresence{
+				History: xmpp.History{MaxStanzas: 0},
+			},
+		},
+	}
+	data, err := xml.Marshal(&pres)
+	if err != nil {
+		t.Error("error on encode:", err)
+	}
+
+	if data != str {
+		t.Errorf("incorrect max stanza: '%d'", muc.History.MaxStanzas)
+	}
+}


### PR DESCRIPTION
if `int` is `0` it will not be decoded - because you set `omitempty`.
Solution is to set use pointer so that `omitempty` would handle the pointer and not the value.
On this value a value like `0` is allowed.

---

if you do not use it like here programmed, please create tests for it.