### PR TITLE
Reply with not-implemented error when there is no route for a received iq get / set

### DIFF
--- a/_examples/go.mod
+++ b/_examples/go.mod
@@ -6,5 +6,7 @@ require (
 	github.com/google/go-cmp v0.3.0 // indirect
 	github.com/processone/mpg123 v1.0.0
 	github.com/processone/soundcloud v1.0.0
-	gosrc.io/xmpp v0.1.1-0.20190622092414-e9c704eff56e
+	gosrc.io/xmpp v0.1.1
 )
+
+replace gosrc.io/xmpp => ./../

--- a/_examples/go.sum
+++ b/_examples/go.sum
@@ -8,9 +8,3 @@ golang.org/x/net v0.0.0-20190110200230-915654e7eabc h1:Yx9JGxI1SBhVLFjpAkWMaO1TF
 golang.org/x/net v0.0.0-20190110200230-915654e7eabc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522 h1:bhOzK9QyoD0ogCnFro1m2mz41+Ib0oOhfJnBp5MR4K4=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-gosrc.io/xmpp v0.1.1-0.20190619120342-a6cbc0c08f52 h1:H5BezaFYvDL9r72ng90ICneftomo1iXx6+BxxZ9jBtg=
-gosrc.io/xmpp v0.1.1-0.20190619120342-a6cbc0c08f52/go.mod h1:WvSgrZF7lMvjd1SH8nVGi7ZGr6gNU7oUuBdwpFTs9nY=
-gosrc.io/xmpp v0.1.1-0.20190619153249-b1dde2330764 h1:jlYtpqdRoBC3Gke7MacXsVpSZL0g5nIBG/b9JVxpAVY=
-gosrc.io/xmpp v0.1.1-0.20190619153249-b1dde2330764/go.mod h1:WvSgrZF7lMvjd1SH8nVGi7ZGr6gNU7oUuBdwpFTs9nY=
-gosrc.io/xmpp v0.1.1-0.20190622092414-e9c704eff56e h1:dgWkSZHo0u54X+kFI8CUPiFoeX0rhmuEgykKfyFeHKI=
-gosrc.io/xmpp v0.1.1-0.20190622092414-e9c704eff56e/go.mod h1:WvSgrZF7lMvjd1SH8nVGi7ZGr6gNU7oUuBdwpFTs9nY=

--- a/client.go
+++ b/client.go
@@ -210,13 +210,13 @@ func (c *Client) recv(keepaliveQuit chan<- struct{}) (err error) {
 		// Handle stream errors
 		switch packet := val.(type) {
 		case StreamError:
-			c.router.Route(c, val)
+			c.router.route(c, val)
 			close(keepaliveQuit)
 			c.streamError(packet.Error.Local, packet.Text)
 			return errors.New("stream error: " + packet.Error.Local)
 		}
 
-		c.router.Route(c, val)
+		c.router.route(c, val)
 	}
 }
 

--- a/component.go
+++ b/component.go
@@ -128,11 +128,11 @@ func (c *Component) recv() (err error) {
 		// Handle stream errors
 		switch p := val.(type) {
 		case StreamError:
-			c.router.Route(c, val)
+			c.router.route(c, val)
 			c.streamError(p.Error.Local, p.Text)
 			return errors.New("stream error: " + p.Error.Local)
 		}
-		c.router.Route(c, val)
+		c.router.route(c, val)
 	}
 }
 

--- a/iq_test.go
+++ b/iq_test.go
@@ -153,3 +153,19 @@ func TestPayloadWithError(t *testing.T) {
 		t.Errorf("incorrect error value: '%s'", parsedIQ.Error.Reason)
 	}
 }
+
+func TestUnknownPayload(t *testing.T) {
+	iq := `<iq type="get" to="service.localhost" id="1" >
+ <query xmlns="unknown:ns"/>
+</iq>`
+	parsedIQ := xmpp.IQ{}
+	err := xml.Unmarshal([]byte(iq), &parsedIQ)
+	if err != nil {
+		t.Errorf("Unmarshal error: %#v (%s)", err, iq)
+		return
+	}
+
+	if parsedIQ.Any.XMLName.Space != "unknown:ns" {
+		t.Errorf("could not extract namespace: '%s'", parsedIQ.Any.XMLName.Space)
+	}
+}

--- a/router.go
+++ b/router.go
@@ -40,7 +40,6 @@ func (r *Router) route(s Sender, p Packet) {
 		match.Handler.HandlePacket(s, p)
 		return
 	}
-
 	// If there is no match and we receive an iq set or get, we need to send a reply
 	if iq, ok := p.(IQ); ok {
 		if iq.Type == IQTypeGet || iq.Type == IQTypeSet {
@@ -52,7 +51,7 @@ func (r *Router) route(s Sender, p Packet) {
 func iqNotImplemented(s Sender, iq IQ) {
 	err := Err{
 		XMLName: xml.Name{Local: "error"},
-		Code:    500,
+		Code:    501,
 		Type:    "cancel",
 		Reason:  "feature-not-implemented",
 	}

--- a/router.go
+++ b/router.go
@@ -29,7 +29,9 @@ func NewRouter() *Router {
 	return &Router{}
 }
 
-func (r *Router) Route(s Sender, p Packet) {
+// route is called by the XMPP client to dispatch stanza received using the set up routes.
+// It is also used by test, but is not supposed to be used directly by users of the library.
+func (r *Router) route(s Sender, p Packet) {
 	var match RouteMatch
 	if r.Match(p, &match) {
 		match.Handler.HandlePacket(s, p)


### PR DESCRIPTION
We reply with an error not-implemented stanza.

Here is an example stanza error:

```
<iq from="service.localhost" type="error" to="test1@localhost/mremond-mbp" id="1" >
 <error type="cancel" code="501" >
  <feature-not-implemented xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/>
 </error>
 <query xmlns="unknown:ns"/>
</iq>
```

Fixes #66 