### PR TITLE
Fix XMPP logger consistency

### DIFF
--- a/_examples/xmpp_echo/xmpp_echo.go
+++ b/_examples/xmpp_echo/xmpp_echo.go
@@ -18,7 +18,7 @@ func main() {
 		Address:      "localhost:5222",
 		Jid:          "test@localhost",
 		Password:     "test",
-		PacketLogger: os.Stdout,
+		StreamLogger: os.Stdout,
 		Insecure:     true,
 	}
 

--- a/_examples/xmpp_jukebox/xmpp_jukebox.go
+++ b/_examples/xmpp_jukebox/xmpp_jukebox.go
@@ -35,7 +35,7 @@ func main() {
 		Address:  *address,
 		Jid:      *jid,
 		Password: *password,
-		// PacketLogger: os.Stdout,
+		// StreamLogger: os.Stdout,
 		Insecure: true,
 	}
 

--- a/client.go
+++ b/client.go
@@ -133,7 +133,7 @@ func (c *Client) Connect() error {
 	//fmt.Fprintf(client.conn, "<presence xml:lang='en'><show>%s</show><status>%s</status></presence>", "chat", "Online")
 	// TODO: Do we always want to send initial presence automatically ?
 	// Do we need an option to avoid that or do we rely on client to send the presence itself ?
-	fmt.Fprintf(c.Session.socketProxy, "<presence/>")
+	fmt.Fprintf(c.Session.streamLogger, "<presence/>")
 
 	// Start the keepalive go routine
 	keepaliveQuit := make(chan struct{})
@@ -166,10 +166,7 @@ func (c *Client) Send(packet stanza.Packet) error {
 		return errors.New("cannot marshal packet " + err.Error())
 	}
 
-	if _, err := fmt.Fprintf(conn, string(data)); err != nil {
-		return errors.New("cannot send packet " + err.Error())
-	}
-	return nil
+	return c.sendWithLogger(string(data))
 }
 
 // SendRaw sends an XMPP stanza as a string to the server.
@@ -182,8 +179,12 @@ func (c *Client) SendRaw(packet string) error {
 		return errors.New("client is not connected")
 	}
 
+	return c.sendWithLogger(packet)
+}
+
+func (c *Client) sendWithLogger(packet string) error {
 	var err error
-	_, err = fmt.Fprintf(conn, packet)
+	_, err = fmt.Fprintf(c.Session.streamLogger, packet)
 	return err
 }
 

--- a/config.go
+++ b/config.go
@@ -10,7 +10,7 @@ type Config struct {
 	Jid            string
 	parsedJid      *Jid // For easier manipulation
 	Password       string
-	PacketLogger   *os.File // Used for debugging
+	StreamLogger   *os.File // Used for debugging
 	Lang           string   // TODO: should default to 'en'
 	ConnectTimeout int      // Client timeout in seconds. Default to 15
 	// Insecure can be set to true to allow to open a session without TLS. If TLS

--- a/stream_logger.go
+++ b/stream_logger.go
@@ -7,20 +7,20 @@ import (
 
 // Mediated Read / Write on socket
 // Used if logFile from Config is not nil
-type socketProxy struct {
+type streamLogger struct {
 	socket  io.ReadWriter // Actual connection
 	logFile *os.File
 }
 
-func newSocketProxy(conn io.ReadWriter, logFile *os.File) io.ReadWriter {
+func newStreamLogger(conn io.ReadWriter, logFile *os.File) io.ReadWriter {
 	if logFile == nil {
 		return conn
 	} else {
-		return &socketProxy{conn, logFile}
+		return &streamLogger{conn, logFile}
 	}
 }
 
-func (sp *socketProxy) Read(p []byte) (n int, err error) {
+func (sp *streamLogger) Read(p []byte) (n int, err error) {
 	n, err = sp.socket.Read(p)
 	if n > 0 {
 		sp.logFile.Write([]byte("RECV:\n")) // Prefix
@@ -32,7 +32,7 @@ func (sp *socketProxy) Read(p []byte) (n int, err error) {
 	return
 }
 
-func (sp *socketProxy) Write(p []byte) (n int, err error) {
+func (sp *streamLogger) Write(p []byte) (n int, err error) {
 	sp.logFile.Write([]byte("SEND:\n")) // Prefix
 	for _, w := range []io.Writer{sp.socket, sp.logFile} {
 		n, err = w.Write(p)
@@ -47,3 +47,7 @@ func (sp *socketProxy) Write(p []byte) (n int, err error) {
 	sp.logFile.Write([]byte("\n\n")) // Separator
 	return len(p), nil
 }
+
+/*
+TODO: Make RECV, SEND prefixes +
+*/


### PR DESCRIPTION
- Rename socketProxy to StreamLogger
- Ensure client send traffic through the logger

Fixes #76 