### PR TITLE
Add support for self-signed certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,32 @@ The goal is to make simple to write simple XMPP clients and components:
 
 The library is designed to have minimal dependencies. For now, the library does not depend on any other library.
 
+## Configuration and connection
+
+### Allowing Insecure TLS connection during development
+
+It is not recommended to disable the check for domain name and certificate chain. Doing so would open your client
+to man-in-the-middle attacks.
+
+However, in development, XMPP servers often use self-signed certificates. In that situation, it is better to add the
+root CA that signed the certificate to your trusted list of root CA. It avoids changing the code and limit the risk
+of shipping an insecure client to production.
+
+That said, if you really want to allow your client to trust any TLS certificate, you can customize Go standard 
+`tls.Config` and set it in Config struct.
+
+Here is an example code to configure a client to allow connecting to a server with self-signed certificate. Note the 
+`InsecureSkipVerify` option. When using this `tls.Config` option, all the checks on the certificate are skipped.
+
+```go
+config := xmpp.Config{
+	Address:      "localhost:5222",
+	Jid:          "test@localhost",
+	Password:     "test",
+	TLSConfig:     tls.Config{InsecureSkipVerify: true},
+}
+```
+
 ## Supported specifications
 
 ### Clients

--- a/_examples/xmpp_echo/xmpp_echo.go
+++ b/_examples/xmpp_echo/xmpp_echo.go
@@ -20,6 +20,7 @@ func main() {
 		Password:     "test",
 		StreamLogger: os.Stdout,
 		Insecure:     true,
+		// TLSConfig: tls.Config{InsecureSkipVerify: true},
 	}
 
 	router := xmpp.NewRouter()

--- a/cert_checker.go
+++ b/cert_checker.go
@@ -86,8 +86,9 @@ func (c *ServerCheck) Check() error {
 			return fmt.Errorf("expecting starttls proceed: %s", err)
 		}
 
-		stanza.DefaultTlsConfig.ServerName = c.domain
-		tlsConn := tls.Client(tcpconn, &stanza.DefaultTlsConfig)
+		var tlsConfig tls.Config
+		tlsConfig.ServerName = c.domain
+		tlsConn := tls.Client(tcpconn, &tlsConfig)
 		// We convert existing connection to TLS
 		if err = tlsConn.Handshake(); err != nil {
 			return err

--- a/config.go
+++ b/config.go
@@ -1,6 +1,7 @@
 package xmpp
 
 import (
+	"crypto/tls"
 	"io"
 	"os"
 )
@@ -13,6 +14,7 @@ type Config struct {
 	StreamLogger   *os.File // Used for debugging
 	Lang           string   // TODO: should default to 'en'
 	ConnectTimeout int      // Client timeout in seconds. Default to 15
+	TLSConfig      tls.Config
 	// Insecure can be set to true to allow to open a session without TLS. If TLS
 	// is supported on the server, we will still try to use it.
 	Insecure      bool

--- a/stanza/starttls.go
+++ b/stanza/starttls.go
@@ -1,11 +1,8 @@
 package stanza
 
 import (
-	"crypto/tls"
 	"encoding/xml"
 )
-
-var DefaultTlsConfig tls.Config
 
 // Used during stream initiation / session establishment
 type TLSProceed struct {

--- a/stream_manager.go
+++ b/stream_manager.go
@@ -119,7 +119,7 @@ func (sm *StreamManager) connect() error {
 			var actualErr ConnError
 			if xerrors.As(err, &actualErr) {
 				if actualErr.Permanent {
-					return xerrors.Errorf("unrecoverable connect error %w", actualErr)
+					return xerrors.Errorf("unrecoverable connect error %#v", actualErr)
 				}
 			}
 			backoff.wait()


### PR DESCRIPTION
- You can now pass you own `tls.Config` in config option to override all TLS behaviour. This makes it possible to use the option `InsecureSkipVerify`
- Better logging / reporting on TLS connection errors 

Fixes #88 