### PR TITLE
init empty TLSConfig, if nothing given

### DIFF
--- a/session.go
+++ b/session.go
@@ -117,6 +117,10 @@ func (s *Session) startTlsIfSupported(conn net.Conn, domain string, o Config) ne
 			return conn
 		}
 
+		if o.TLSConfig == nil {
+			o.TLSConfig = &tls.Config{}
+		}
+
 		if o.TLSConfig.ServerName == "" {
 			o.TLSConfig.ServerName = domain
 		}


### PR DESCRIPTION
fix error on implement #90 :

```
Jul 16 00:07:41 apus hook2xmpp[7229]: panic: runtime error: invalid memory address or nil pointer dereference
Jul 16 00:07:41 apus hook2xmpp[7229]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x80 pc=0x77a0e4]
Jul 16 00:07:41 apus hook2xmpp[7229]: goroutine 24 [running]:
Jul 16 00:07:41 apus hook2xmpp[7229]: gosrc.io/xmpp.(*Session).startTlsIfSupported(0xc000137d40, 0xd2e6c0, 0xc000010bc0, 0xc00009a48a, 0xc, 0xc0000a0280, 0x11, 0xc00009a480, 0x20, 0xc0002a00c0, ...)
Jul 16 00:07:41 apus hook2xmpp[7229]:         /go/src/gosrc.io/xmpp/session.go:120 +0x274
Jul 16 00:07:41 apus hook2xmpp[7229]: gosrc.io/xmpp.NewSession(0xd2e6c0, 0xc000010bc0, 0xc0000a0280, 0x11, 0xc00009a480, 0x20, 0xc0002a00c0, 0xc0000a02c0, 0x10, 0x0, ...)
Jul 16 00:07:41 apus hook2xmpp[7229]:         /go/src/gosrc.io/xmpp/session.go:38 +0xf7
Jul 16 00:07:41 apus hook2xmpp[7229]: gosrc.io/xmpp.(*Client).Connect(0xc0000a8be0, 0xc0001b2360, 0x1234540)
Jul 16 00:07:41 apus hook2xmpp[7229]:         /go/src/gosrc.io/xmpp/client.go:127 +0x125
Jul 16 00:07:41 apus hook2xmpp[7229]: gosrc.io/xmpp.(*StreamManager).connect(0xc0002a00f0, 0x1, 0xc00003b798)
Jul 16 00:07:41 apus hook2xmpp[7229]:         /go/src/gosrc.io/xmpp/stream_manager.go:118 +0xe2
Jul 16 00:07:41 apus hook2xmpp[7229]: gosrc.io/xmpp.(*StreamManager).Run(0xc0002a00f0, 0xc60960, 0xc00003b7b8)
Jul 16 00:07:41 apus hook2xmpp[7229]:         /go/src/gosrc.io/xmpp/stream_manager.go:93 +0xa9
```