### PR TITLE
Add initial support for stream management

### DIFF
--- a/client.go
+++ b/client.go
@@ -282,9 +282,6 @@ func keepalive(conn net.Conn, quit <-chan struct{}) {
 				_ = conn.Close()
 				return
 			}
-		case <-time.After(3 * time.Second):
-			_ = conn.Close()
-			return
 		case <-quit:
 			ticker.Stop()
 			return

--- a/client.go
+++ b/client.go
@@ -252,14 +252,12 @@ func (c *Client) recv(state SMState, keepaliveQuit chan<- struct{}) (err error) 
 			return errors.New("stream error: " + packet.Error.Local)
 		// Process Stream management nonzas
 		case stanza.SMRequest:
-			fmt.Println("MREMOND: inbound: ", state.Inbound)
 			answer := stanza.SMAnswer{XMLName: xml.Name{
 				Space: stanza.NSStreamManagement,
 				Local: "a",
 			}, H: state.Inbound}
 			c.Send(answer)
 		default:
-			fmt.Println(packet)
 			state.Inbound++
 		}
 

--- a/component.go
+++ b/component.go
@@ -108,6 +108,10 @@ func (c *Component) Connect() error {
 	}
 }
 
+func (c *Component) Resume() error {
+	return errors.New("components do not support stream management")
+}
+
 func (c *Component) Disconnect() {
 	_ = c.SendRaw("</stream:stream>")
 	// TODO: Add a way to wait for stream close acknowledgement from the server for clean disconnect

--- a/session.go
+++ b/session.go
@@ -195,7 +195,6 @@ func (s *Session) resume(o Config) bool {
 			}
 			return true
 		case stanza.SMFailed:
-			fmt.Println("MREMOND SM Failed")
 		default:
 			s.err = errors.New("unexpected reply to SM resume")
 		}
@@ -272,7 +271,6 @@ func (s *Session) EnableStreamManagement(o Config) {
 		case stanza.SMFailed:
 			// TODO: Store error in SMState, for later inspection
 		default:
-			fmt.Println(p)
 			s.err = errors.New("unexpected reply to SM enable")
 		}
 	}

--- a/session.go
+++ b/session.go
@@ -270,7 +270,7 @@ func (s *Session) EnableStreamManagement(o Config) {
 		case stanza.SMEnabled:
 			s.SMState = SMState{Id: p.Id}
 		case stanza.SMFailed:
-			// TODO: Store error in SMState
+			// TODO: Store error in SMState, for later inspection
 		default:
 			fmt.Println(p)
 			s.err = errors.New("unexpected reply to SM enable")

--- a/stanza/iq.go
+++ b/stanza/iq.go
@@ -2,7 +2,6 @@ package stanza
 
 import (
 	"encoding/xml"
-	"fmt"
 )
 
 /*
@@ -99,7 +98,6 @@ func (iq *IQ) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 				var xmppError Err
 				err = d.DecodeElement(&xmppError, &tt)
 				if err != nil {
-					fmt.Println(err)
 					return err
 				}
 				iq.Error = xmppError

--- a/stanza/parser.go
+++ b/stanza/parser.go
@@ -63,6 +63,8 @@ func NextPacket(p *xml.Decoder) (Packet, error) {
 		return decodeClient(p, se)
 	case NSComponent:
 		return decodeComponent(p, se)
+	case NSStreamManagement:
+		return sm.decode(p, se)
 	default:
 		return nil, errors.New("unknown namespace " +
 			se.Name.Space + " <" + se.Name.Local + "/>")
@@ -133,7 +135,7 @@ func decodeClient(p *xml.Decoder, se xml.StartElement) (Packet, error) {
 	}
 }
 
-// decodeClient decodes all known packets in the component namespace.
+// decodeComponent decodes all known packets in the component namespace.
 func decodeComponent(p *xml.Decoder, se xml.StartElement) (Packet, error) {
 	switch se.Name.Local {
 	case "handshake": // handshake is used to authenticate components

--- a/stanza/stream_management.go
+++ b/stanza/stream_management.go
@@ -1,0 +1,121 @@
+package stanza
+
+import (
+	"encoding/xml"
+	"errors"
+)
+
+const (
+	NSStreamManagement = "urn:xmpp:sm:3"
+)
+
+// Enabled as defined in Stream Management spec
+// Reference: https://xmpp.org/extensions/xep-0198.html#enable
+type SMEnabled struct {
+	XMLName  xml.Name `xml:"urn:xmpp:sm:3 enabled"`
+	Id       string   `xml:"id,attr,omitempty"`
+	Location string   `xml:"location,attr,omitempty"`
+	Resume   string   `xml:"resume,attr,omitempty"`
+	Max      uint     `xml:"max,attr,omitempty"`
+}
+
+func (SMEnabled) Name() string {
+	return "Stream Management: enabled"
+}
+
+// Request as defined in Stream Management spec
+// Reference: https://xmpp.org/extensions/xep-0198.html#acking
+type SMRequest struct {
+	XMLName xml.Name `xml:"urn:xmpp:sm:3 r"`
+}
+
+func (SMRequest) Name() string {
+	return "Stream Management: request"
+}
+
+// Answer as defined in Stream Management spec
+// Reference: https://xmpp.org/extensions/xep-0198.html#acking
+type SMAnswer struct {
+	XMLName xml.Name `xml:"urn:xmpp:sm:3 a"`
+	H       uint     `xml:"h,attr,omitempty"`
+}
+
+func (SMAnswer) Name() string {
+	return "Stream Management: answer"
+}
+
+// Resumed as defined in Stream Management spec
+// Reference: https://xmpp.org/extensions/xep-0198.html#acking
+type SMResumed struct {
+	XMLName xml.Name `xml:"urn:xmpp:sm:3 resumed"`
+	PrevId  string   `xml:"previd,attr,omitempty"`
+	H       uint     `xml:"h,attr,omitempty"`
+}
+
+func (SMResumed) Name() string {
+	return "Stream Management: resumed"
+}
+
+// Failed as defined in Stream Management spec
+// Reference: https://xmpp.org/extensions/xep-0198.html#acking
+type SMFailed struct {
+	XMLName xml.Name `xml:"urn:xmpp:sm:3 failed"`
+	// TODO: Handle decoding error cause (need custom parsing).
+}
+
+func (SMFailed) Name() string {
+	return "Stream Management: failed"
+}
+
+type smDecoder struct{}
+
+var sm smDecoder
+
+// decode decodes all known nonza in the stream management namespace.
+func (s smDecoder) decode(p *xml.Decoder, se xml.StartElement) (Packet, error) {
+	switch se.Name.Local {
+	case "enabled":
+		return s.decodeEnabled(p, se)
+	case "resumed":
+		return s.decodeResumed(p, se)
+	case "r":
+		return s.decodeRequest(p, se)
+	case "h":
+		return s.decodeAnswer(p, se)
+	case "failed":
+		return s.decodeFailed(p, se)
+	default:
+		return nil, errors.New("unexpected XMPP packet " +
+			se.Name.Space + " <" + se.Name.Local + "/>")
+	}
+}
+
+func (smDecoder) decodeEnabled(p *xml.Decoder, se xml.StartElement) (SMEnabled, error) {
+	var packet SMEnabled
+	err := p.DecodeElement(&packet, &se)
+	return packet, err
+}
+
+func (smDecoder) decodeResumed(p *xml.Decoder, se xml.StartElement) (SMResumed, error) {
+	var packet SMResumed
+	err := p.DecodeElement(&packet, &se)
+	return packet, err
+}
+
+func (smDecoder) decodeRequest(p *xml.Decoder, se xml.StartElement) (SMRequest, error) {
+	var packet SMRequest
+	err := p.DecodeElement(&packet, &se)
+	return packet, err
+}
+
+func (smDecoder) decodeAnswer(p *xml.Decoder, se xml.StartElement) (SMAnswer, error) {
+	var packet SMAnswer
+	err := p.DecodeElement(&packet, &se)
+	return packet, err
+}
+
+func (smDecoder) decodeFailed(p *xml.Decoder, se xml.StartElement) (SMFailed, error) {
+	var packet SMFailed
+	err := p.DecodeElement(&packet, &se)
+	return packet, err
+}


### PR DESCRIPTION
For now it support enabling SM, replying to ack requests from server, and trying resuming the session with existing Stream Management state.

First step in having full support for #47 