### PR TITLE
Generic node should use cdata instead of innerxml

### DIFF
--- a/_examples/go.sum
+++ b/_examples/go.sum
@@ -4,3 +4,4 @@ github.com/processone/soundcloud v1.0.0/go.mod h1:kDLeWpkRtN3C8kIReQdxoiRi92P9xR
 golang.org/x/net v0.0.0-20190110200230-915654e7eabc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522 h1:bhOzK9QyoD0ogCnFro1m2mz41+Ib0oOhfJnBp5MR4K4=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/cmd/go.sum
+++ b/cmd/go.sum
@@ -143,6 +143,7 @@ golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522 h1:bhOzK9QyoD0ogCnFro1m2mz41+Ib0oOhfJnBp5MR4K4=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.12
 
 require (
 	github.com/google/go-cmp v0.3.0
-	golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522
+	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7
 )

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,5 @@ github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522 h1:bhOzK9QyoD0ogCnFro1m2mz41+Ib0oOhfJnBp5MR4K4=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/stanza/error_test.go
+++ b/stanza/error_test.go
@@ -1,0 +1,31 @@
+package stanza
+
+import (
+	"encoding/xml"
+	"testing"
+)
+
+func TestErr_UnmarshalXML(t *testing.T) {
+	packet := `
+ <iq from='pubsub.example.com'
+       id='kj4vz31m'
+       to='romeo@example.net/foo'
+       type='error'>
+  <error type='wait'>
+    <resource-constraint
+        xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
+    <text xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'>System overloaded, please retry</text>
+  </error>
+ </iq>`
+
+	parsedIQ := IQ{}
+	data := []byte(packet)
+	if err := xml.Unmarshal(data, &parsedIQ); err != nil {
+		t.Errorf("Unmarshal(%s) returned error", data)
+	}
+
+	xmppError := parsedIQ.Error
+	if xmppError.Text != "System overloaded, please retry" {
+		t.Errorf("Could not extract error text: '%s'", xmppError.Text)
+	}
+}

--- a/stanza/iot_test.go
+++ b/stanza/iot_test.go
@@ -21,6 +21,6 @@ func TestControlSet(t *testing.T) {
 	}
 
 	if cs, ok := parsedIQ.Payload.(*ControlSet); !ok {
-		t.Errorf("Paylod is not an iot control set: %v", cs)
+		t.Errorf("Payload is not an iot control set: %v", cs)
 	}
 }

--- a/stanza/iq.go
+++ b/stanza/iq.go
@@ -22,7 +22,7 @@ type IQ struct { // Info/Query
 	//    request."
 	Payload IQPayload `xml:",omitempty"`
 	Error   Err       `xml:"error,omitempty"`
-	// Any is used to decode unknown payload as a generique structure
+	// Any is used to decode unknown payload as a generic structure
 	Any *Node `xml:",any"`
 }
 

--- a/stanza/node.go
+++ b/stanza/node.go
@@ -10,7 +10,7 @@ import "encoding/xml"
 type Node struct {
 	XMLName xml.Name
 	Attrs   []xml.Attr `xml:"-"`
-	Content string     `xml:",innerxml"`
+	Content string     `xml:",cdata"`
 	Nodes   []Node     `xml:",any"`
 }
 
@@ -47,5 +47,8 @@ func (n Node) MarshalXML(e *xml.Encoder, start xml.StartElement) (err error) {
 
 	err = e.EncodeToken(start)
 	e.EncodeElement(n.Nodes, xml.StartElement{Name: n.XMLName})
+	if n.Content != "" {
+		e.EncodeToken(xml.CharData(n.Content))
+	}
 	return e.EncodeToken(xml.EndElement{Name: start.Name})
 }

--- a/stanza/node_test.go
+++ b/stanza/node_test.go
@@ -1,0 +1,30 @@
+package stanza
+
+import (
+	"encoding/xml"
+	"testing"
+)
+
+func TestNode_Marshal(t *testing.T) {
+	jsonData := []byte("{\"key\":\"value\"}")
+
+	iqResp := NewIQ(Attrs{Type: "result", From: "admin@localhost", To: "test@localhost", Id: "1"})
+	iqResp.Any = &Node{
+		XMLName: xml.Name{Space: "myNS", Local: "space"},
+		Content: string(jsonData),
+	}
+
+	bytes, err := xml.Marshal(iqResp)
+	if err != nil {
+		t.Errorf("Could not marshal XML: %v", err)
+	}
+
+	parsedIQ := IQ{}
+	if err := xml.Unmarshal(bytes, &parsedIQ); err != nil {
+		t.Errorf("Unmarshal returned error: %v", err)
+	}
+
+	if parsedIQ.Any.Content != string(jsonData) {
+		t.Errorf("Cannot find generic any payload in parsedIQ: '%s'", parsedIQ.Any.Content)
+	}
+}


### PR DESCRIPTION
It fixes #110, but the things to note, is still that the best approach is to create custom payload structs to support custom XMPP stanza. This is already properly described in `stanza` package documentation: https://github.com/FluuxIO/go-xmpp/blob/master/stanza/README.md#adding-your-own-custom-extensions-on-stanzas

See #110 & #111 