### PR TITLE
IQ result routes

### DIFF
--- a/client.go
+++ b/client.go
@@ -235,14 +235,14 @@ func (c *Client) Send(packet stanza.Packet) error {
 //           // Handle the result here
 //   })
 //
-func (c *Client) SendIQ(ctx context.Context, iq stanza.IQ, handler HandlerFunc) (*IqResultRoute, error) {
+func (c *Client) SendIQ(ctx context.Context, iq stanza.IQ, handler IQResultHandlerFunc) (*IQResultRoute, error) {
 	if iq.Attrs.Type != "set" && iq.Attrs.Type != "get" {
 		return nil, ErrCanOnlySendGetOrSetIq
 	}
 	if err := c.Send(iq); err != nil {
 		return nil, err
 	}
-	return c.router.NewIqResultRoute(ctx, iq.Attrs.Id).HandlerFunc(handler), nil
+	return c.router.NewIQResultRoute(ctx, iq.Attrs.Id).HandlerFunc(handler), nil
 }
 
 // SendRaw sends an XMPP stanza as a string to the server.

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/google/go-cmp v0.3.1
+	github.com/google/uuid v1.1.1
 	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7
 	nhooyr.io/websocket v1.6.5
 )

--- a/go.sum
+++ b/go.sum
@@ -21,9 +21,12 @@ github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190908185732-236ed259b199/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/knq/sysutil v0.0.0-20181215143952-f05b59f0f307/go.mod h1:BjPj+aVjl9FW/cCGiF3nGh5v+9Gd3VCgBQbod/GlMaQ=

--- a/router_test.go
+++ b/router_test.go
@@ -13,18 +13,18 @@ import (
 // ============================================================================
 // Test route & matchers
 
-func TestIqResultRoutes(t *testing.T) {
+func TestIQResultRoutes(t *testing.T) {
 	t.Parallel()
 	router := NewRouter()
 
-	if router.iqResultRoutes == nil {
+	if router.IQResultRoutes == nil {
 		t.Fatal("NewRouter does not initialize isResultRoutes")
 	}
 
 	// Check other IQ does not matcah
 	conn := NewSenderMock()
 	iq := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeResult, Id: "4321"})
-	router.NewIqResultRoute(context.Background(), "1234").HandlerFunc(func(s Sender, p stanza.Packet) {
+	router.NewIQResultRoute(context.Background(), "1234").HandlerFunc(func(ctx context.Context, s Sender, iq stanza.IQ) {
 		_ = s.SendRaw(successFlag)
 	})
 	if conn.String() == successFlag {
@@ -51,7 +51,7 @@ func TestIqResultRoutes(t *testing.T) {
 	conn = NewSenderMock()
 	ctx, cancel := context.WithCancel(context.Background())
 	iq = stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeResult, Id: "1234"})
-	router.NewIqResultRoute(ctx, "1234").HandlerFunc(func(s Sender, p stanza.Packet) {
+	router.NewIQResultRoute(ctx, "1234").HandlerFunc(func(ctx context.Context, s Sender, iq stanza.IQ) {
 		_ = s.SendRaw(successFlag)
 	}).TimeoutHandlerFunc(func(err error) {
 		conn.SendRaw(cancelledFlag)

--- a/router_test.go
+++ b/router_test.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/xml"
-	"runtime"
 	"testing"
+	"time"
 
 	"gosrc.io/xmpp/stanza"
 )
@@ -16,52 +16,41 @@ import (
 func TestIQResultRoutes(t *testing.T) {
 	t.Parallel()
 	router := NewRouter()
+	conn := NewSenderMock()
 
 	if router.IQResultRoutes == nil {
 		t.Fatal("NewRouter does not initialize isResultRoutes")
 	}
 
-	// Check other IQ does not matcah
-	conn := NewSenderMock()
-	iq := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeResult, Id: "4321"})
-	router.NewIQResultRoute(context.Background(), "1234").HandlerFunc(func(ctx context.Context, s Sender, iq stanza.IQ) {
-		_ = s.SendRaw(successFlag)
-	})
-	if conn.String() == successFlag {
-		t.Fatal("IQ result with wrong ID was matched")
-	}
-
 	// Check if the IQ handler was called
-	conn = NewSenderMock()
-	iq = stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeResult, Id: "1234"})
-	router.route(conn, iq)
-	if conn.String() != successFlag {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*100)
+	defer cancel()
+	iq := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeResult, Id: "1234"})
+	res := router.NewIQResultRoute(ctx, "1234")
+	go router.route(conn, iq)
+	select {
+	case <-ctx.Done():
 		t.Fatal("IQ result was not matched")
+	case <-res:
+		// Success
 	}
 
-	// The match must only happen once, so we if receive the same package again it
-	// must not be matched.
-	conn = NewSenderMock()
-	router.route(conn, iq)
-	if conn.String() == successFlag {
-		t.Fatal("IQ result was matched twice")
+	// The match must only happen once, so the id should no longer be in IQResultRoutes
+	if _, ok := router.IQResultRoutes[iq.Attrs.Id]; ok {
+		t.Fatal("IQ ID was not removed from the route map")
 	}
 
-	// After cancelling a route it should no longer match
-	conn = NewSenderMock()
-	ctx, cancel := context.WithCancel(context.Background())
-	iq = stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeResult, Id: "1234"})
-	router.NewIQResultRoute(ctx, "1234").HandlerFunc(func(ctx context.Context, s Sender, iq stanza.IQ) {
-		_ = s.SendRaw(successFlag)
-	}).TimeoutHandlerFunc(func(err error) {
-		conn.SendRaw(cancelledFlag)
-	})
-	cancel()
-	// Yield the processor so the cancellation goroutine is triggered
-	runtime.Gosched()
-	router.route(conn, iq)
-	if conn.String() != cancelledFlag {
-		t.Fatal("IQ result route was matched after cancellation")
+	// Check other IQ does not matcah
+	ctx, cancel = context.WithTimeout(context.Background(), time.Millisecond*100)
+	defer cancel()
+	iq.Attrs.Id = "4321"
+	res = router.NewIQResultRoute(ctx, "1234")
+	go router.route(conn, iq)
+	select {
+	case <-ctx.Done():
+		// Success
+	case <-res:
+		t.Fatal("IQ result with wrong ID was matched")
 	}
 }
 

--- a/stanza/iq.go
+++ b/stanza/iq.go
@@ -2,6 +2,8 @@ package stanza
 
 import (
 	"encoding/xml"
+
+	"github.com/google/uuid"
 )
 
 /*
@@ -31,8 +33,12 @@ type IQPayload interface {
 }
 
 func NewIQ(a Attrs) IQ {
-	// TODO generate IQ ID if not set
 	// TODO ensure that type is set, as it is required
+	if a.Id == "" {
+		if id, err := uuid.NewRandom(); err == nil {
+			a.Id = id.String()
+		}
+	}
 	return IQ{
 		XMLName: xml.Name{Local: "iq"},
 		Attrs:   a,

--- a/stanza/iq_test.go
+++ b/stanza/iq_test.go
@@ -34,6 +34,24 @@ func TestUnmarshalIqs(t *testing.T) {
 	}
 }
 
+func TestGenerateIqId(t *testing.T) {
+	t.Parallel()
+	iq := stanza.NewIQ(stanza.Attrs{Id: "1"})
+	if iq.Id != "1" {
+		t.Errorf("NewIQ replaced id with %s", iq.Id)
+	}
+
+	iq = stanza.NewIQ(stanza.Attrs{})
+	if iq.Id != "1" {
+		t.Error("NewIQ did not generate an Id")
+	}
+
+	otherIq := stanza.NewIQ(stanza.Attrs{})
+	if iq.Id == otherIq.Id {
+		t.Errorf("NewIQ generated two identical ids: %s", iq.Id)
+	}
+}
+
 func TestGenerateIq(t *testing.T) {
 	iq := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeResult, From: "admin@localhost", To: "test@localhost", Id: "1"})
 	payload := stanza.DiscoInfo{

--- a/stream_manager.go
+++ b/stream_manager.go
@@ -1,6 +1,7 @@
 package xmpp
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"time"
@@ -26,6 +27,7 @@ type StreamClient interface {
 	Connect() error
 	Resume(state SMState) error
 	Send(packet stanza.Packet) error
+	SendIQ(ctx context.Context, iq stanza.IQ) (chan stanza.IQ, error)
 	SendRaw(packet string) error
 	Disconnect()
 	SetHandler(handler EventHandler)
@@ -35,6 +37,7 @@ type StreamClient interface {
 // It is mostly use in callback to pass a limited subset of the stream client interface
 type Sender interface {
 	Send(packet stanza.Packet) error
+	SendIQ(ctx context.Context, iq stanza.IQ) (chan stanza.IQ, error)
 	SendRaw(packet string) error
 }
 


### PR DESCRIPTION
This is an attempt to fix #78. The approach I am taking is to introduce an API like this to the router:

```go
router.NewIqResultRoute(context.Background(), "9128171").HandlerFunc(func (s Sender, p stanza.Packet) {
    // Process IQ result 
})
```

The context is there to support cancellation and timeouts. They have become a pretty standard feature in golang webservers, and work well here. With a timeout the example becomes:

```go
router.NewIqResultRoute(context.WithTimeout(time.Second * 30, context.Background()), "9128171")
  .HandlerFunc(func (s Sender, p stanza.Packet) {
      // Process IQ result 
  })
  .TimeoutHandlerFunc(func (err error) {
      // Handle a timeout
  })
```

To make this a little easier to use I am thinking of adding a method to `Client` to combine sending an IQ and adding a result route. Something like:

```go
func (c Client) SendIq(iq stanza.Packet, handler HandlerFunc) (*IqResultRoute, error) {
    if err := c.Send(iq); err != nil {
        return nil, err
    }
    return c.router.NewIqResultRoute(context.Background(), iq.Attrs.id).HandlerFunc(handler), nil
}
```

@mremond Does this look sensible to you?

Remaining TODO items:

* [x] Add router tests
* [x] Expire old entries in iqResultRoutes
* [x] If a result route is replaced cancel its context (if possible?)