### PR TITLE
Increase size of XML decoder internal buffers

### DIFF
--- a/websocket_transport.go
+++ b/websocket_transport.go
@@ -1,6 +1,7 @@
 package xmpp
 
 import (
+	"bufio"
 	"context"
 	"encoding/xml"
 	"errors"
@@ -57,7 +58,7 @@ func (t *WebsocketTransport) Connect() (string, error) {
 	t.wsConn = wsConn
 	t.startReader()
 
-	t.decoder = xml.NewDecoder(t)
+	t.decoder = xml.NewDecoder(bufio.NewReaderSize(t, maxPacketSize))
 	t.decoder.CharsetReader = t.Config.CharsetReader
 
 	return t.StartStream()

--- a/xmpp_transport.go
+++ b/xmpp_transport.go
@@ -1,6 +1,7 @@
 package xmpp
 
 import (
+	"bufio"
 	"crypto/tls"
 	"encoding/xml"
 	"errors"
@@ -37,7 +38,7 @@ func (t *XMPPTransport) Connect() (string, error) {
 	}
 
 	t.readWriter = newStreamLogger(t.conn, t.logFile)
-	t.decoder = xml.NewDecoder(t.readWriter)
+	t.decoder = xml.NewDecoder(bufio.NewReaderSize(t.readWriter, maxPacketSize))
 	t.decoder.CharsetReader = t.Config.CharsetReader
 	return t.StartStream()
 }
@@ -90,7 +91,7 @@ func (t *XMPPTransport) StartTLS() error {
 
 	t.conn = tlsConn
 	t.readWriter = newStreamLogger(tlsConn, t.logFile)
-	t.decoder = xml.NewDecoder(t.readWriter)
+	t.decoder = xml.NewDecoder(bufio.NewReaderSize(t.readWriter, maxPacketSize))
 	t.decoder.CharsetReader = t.Config.CharsetReader
 
 	if !t.TLSConfig.InsecureSkipVerify {


### PR DESCRIPTION
Since a `Transport` (and a `streamlogger`) does not implement `io.ByteReader`, `xml.Decoder` wraps it using `bufio.NewReader(transport)` so it can easily read bytes one at a time. This has the unfortunate effect of resulting in a panic if we try to parse a stanza that is larger than the default buffer size of 4096 bytes.

To fix this we wrap the transport using `bufio.NewReaderSize()` with a much larger buffer size.

Before the transport work this bug was already present as far as I can see, but only if you enabled logging.
