### PR TITLE
SIGSEGV in xmpp_component example with Prosody #126

### DIFF
--- a/component.go
+++ b/component.go
@@ -7,10 +7,8 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"io"
-	"log"
-
 	"gosrc.io/xmpp/stanza"
+	"io"
 )
 
 type ComponentOptions struct {
@@ -125,9 +123,6 @@ func (c *Component) SetHandler(handler EventHandler) {
 // Receiver Go routine receiver
 func (c *Component) recv() (err error) {
 	for {
-		if c.transport.GetDecoder() == nil {
-			log.Fatal("Decoder is nil ! It should be initialized after a successful connection to the server.")
-		}
 		val, err := stanza.NextPacket(c.transport.GetDecoder())
 		if err != nil {
 			c.updateState(StateDisconnected)

--- a/component.go
+++ b/component.go
@@ -50,7 +50,6 @@ type Component struct {
 
 	// read / write
 	socketProxy io.ReadWriter // TODO
-	decoder     *xml.Decoder
 }
 
 func NewComponent(opts ComponentOptions, r *Router) (*Component, error) {
@@ -90,7 +89,7 @@ func (c *Component) Resume(sm SMState) error {
 	}
 
 	// Check server response for authentication
-	val, err := stanza.NextPacket(c.decoder)
+	val, err := stanza.NextPacket(c.transport.GetDecoder())
 	if err != nil {
 		c.updateState(StatePermanentError)
 		return NewConnError(err, true)
@@ -125,7 +124,7 @@ func (c *Component) SetHandler(handler EventHandler) {
 // Receiver Go routine receiver
 func (c *Component) recv() (err error) {
 	for {
-		val, err := stanza.NextPacket(c.decoder)
+		val, err := stanza.NextPacket(c.transport.GetDecoder())
 		if err != nil {
 			c.updateState(StateDisconnected)
 			return err

--- a/component.go
+++ b/component.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 
 	"gosrc.io/xmpp/stanza"
 )
@@ -124,6 +125,9 @@ func (c *Component) SetHandler(handler EventHandler) {
 // Receiver Go routine receiver
 func (c *Component) recv() (err error) {
 	for {
+		if c.transport.GetDecoder() == nil {
+			log.Fatal("Decoder is nil ! It should be initialized after a successful connection to the server.")
+		}
 		val, err := stanza.NextPacket(c.transport.GetDecoder())
 		if err != nil {
 			c.updateState(StateDisconnected)

--- a/component_test.go
+++ b/component_test.go
@@ -1,8 +1,12 @@
 package xmpp
 
 import (
+	"fmt"
 	"testing"
 )
+
+const testComponentDomain = "localhost"
+const testComponentPort = "15222"
 
 func TestHandshake(t *testing.T) {
 	opts := ComponentOptions{
@@ -29,4 +33,42 @@ func TestGenerateHandshake(t *testing.T) {
 // This validates that Component conforms to StreamClient interface.
 func TestStreamManager(t *testing.T) {
 	NewStreamManager(&Component{}, nil)
+}
+
+// Tests that the decoder is properly initialized when connecting a component to a server.
+// The decoder is expected to be built after a valid connection
+// Based on the xmpp_component example.
+func TestDecoder(t *testing.T) {
+	testComponentAddess := fmt.Sprintf("%s:%s", testComponentDomain, testComponentPort)
+	mock := ServerMock{}
+	mock.Start(t, testComponentAddess, handlerConnectSuccess)
+
+	opts := ComponentOptions{
+		TransportConfiguration: TransportConfiguration{
+			Address: testComponentAddess,
+			Domain:  "localhost",
+		},
+		Domain:   testComponentDomain,
+		Secret:   "mypass",
+		Name:     "Test Component",
+		Category: "gateway",
+		Type:     "service",
+	}
+	router := NewRouter()
+	c, err := NewComponent(opts, router)
+	if err != nil {
+		t.Errorf("%+v", err)
+	}
+	c.transport, err = NewComponentTransport(c.ComponentOptions.TransportConfiguration)
+	if err != nil {
+		t.Errorf("%+v", err)
+	}
+	_, err = c.transport.Connect()
+	if err != nil {
+		t.Errorf("%+v", err)
+	}
+	if c.transport.GetDecoder() == nil {
+		t.Errorf("Failed to initialize decoder. Decoder is nil.")
+	}
+
 }

--- a/stanza/parser.go
+++ b/stanza/parser.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 )
 
 // Reads and checks the opening XMPP stream element.
@@ -50,9 +49,6 @@ func InitStream(p *xml.Decoder) (sessionID string, err error) {
 // TODO Use an interface to return packets interface xmppDecoder
 // TODO make auth and bind use NextPacket instead of directly NextStart
 func NextPacket(p *xml.Decoder) (Packet, error) {
-	if p == nil {
-		log.Fatal("Decoder is nil ! It should be initialized after a successful connection to the server.")
-	}
 	// Read start element to find out how we want to parse the XMPP packet
 	se, err := NextStart(p)
 	if err != nil {

--- a/stanza/parser.go
+++ b/stanza/parser.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 )
 
 // Reads and checks the opening XMPP stream element.
@@ -49,6 +50,9 @@ func InitStream(p *xml.Decoder) (sessionID string, err error) {
 // TODO Use an interface to return packets interface xmppDecoder
 // TODO make auth and bind use NextPacket instead of directly NextStart
 func NextPacket(p *xml.Decoder) (Packet, error) {
+	if p == nil {
+		log.Fatal("Decoder is nil ! It should be initialized after a successful connection to the server.")
+	}
 	// Read start element to find out how we want to parse the XMPP packet
 	se, err := NextStart(p)
 	if err != nil {

--- a/websocket_transport.go
+++ b/websocket_transport.go
@@ -20,6 +20,7 @@ const pingTimeout = time.Duration(5) * time.Second
 
 var ServerDoesNotSupportXmppOverWebsocket = errors.New("The websocket server does not support the xmpp subprotocol")
 
+// The decoder is expected to be initialized after connecting to a server.
 type WebsocketTransport struct {
 	Config  TransportConfiguration
 	decoder *xml.Decoder

--- a/xmpp_transport.go
+++ b/xmpp_transport.go
@@ -14,6 +14,7 @@ import (
 )
 
 // XMPPTransport implements the XMPP native TCP transport
+// The decoder is expected to be initialized after connecting to a server.
 type XMPPTransport struct {
 	openStatement string
 	Config        TransportConfiguration


### PR DESCRIPTION
In the current code, the decoder is never initialized. The decoder seems to have been "moved to the Transport interface", therefore is does not seem necessary to keep it in the Component struct.  
Also, removing it should prevent usage without initialization. 