### PR TITLE
Removed codeship and codecov. We now use github actions and coveralls.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fluux XMPP
 
-[![Codeship Status for FluuxIO/xmpp](https://app.codeship.com/projects/dba7f300-d145-0135-6c51-26e28af241d2/status?branch=master)](https://app.codeship.com/projects/262399) [![GoDoc](https://godoc.org/gosrc.io/xmpp?status.svg)](https://godoc.org/gosrc.io/xmpp) [![GoReportCard](https://goreportcard.com/badge/gosrc.io/xmpp)](https://goreportcard.com/report/fluux.io/xmpp) [![Coverage Status](https://coveralls.io/repos/github/FluuxIO/go-xmpp/badge.svg?branch=master)](https://coveralls.io/github/FluuxIO/go-xmpp?branch=master)
+[![GoDoc](https://godoc.org/gosrc.io/xmpp?status.svg)](https://godoc.org/gosrc.io/xmpp) [![GoReportCard](https://goreportcard.com/badge/gosrc.io/xmpp)](https://goreportcard.com/report/fluux.io/xmpp) [![Coverage Status](https://coveralls.io/repos/github/FluuxIO/go-xmpp/badge.svg?branch=master)](https://coveralls.io/github/FluuxIO/go-xmpp?branch=master)
 
 Fluux XMPP is a Go XMPP library, focusing on simplicity, simple automation, and IoT.
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,1 +1,0 @@
-comment: off

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -1,5 +1,0 @@
-build:
-  build:
-    image: fluux/build
-    dockerfile: Dockerfile
-  encrypted_env_file: codeship.env.encrypted

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -1,5 +1,0 @@
-- type: serial
-  steps:
-  - name: test
-    service: build
-    command: ./test.sh

--- a/codeship.env.encrypted
+++ b/codeship.env.encrypted
@@ -1,1 +1,0 @@
-yVKgVFeKW6SSnC/KgLYpfYtTcqqTke1gOIW5GUiVvRijnhweOJiYKFPmwPjpt1FVrg4WVELQUNbxn3lmfyHVVF7r


### PR DESCRIPTION
Removing codecov and codeship as we now use coveralls and github actions