### PR TITLE
Fix updating of EventManager.CurrentState

### DIFF
--- a/client.go
+++ b/client.go
@@ -60,21 +60,21 @@ type EventManager struct {
 	Handler EventHandler
 }
 
-func (em EventManager) updateState(state ConnState) {
+func (em *EventManager) updateState(state ConnState) {
 	em.CurrentState = state
 	if em.Handler != nil {
 		em.Handler(Event{State: em.CurrentState})
 	}
 }
 
-func (em EventManager) disconnected(state SMState) {
+func (em *EventManager) disconnected(state SMState) {
 	em.CurrentState = StateDisconnected
 	if em.Handler != nil {
 		em.Handler(Event{State: em.CurrentState, SMState: state})
 	}
 }
 
-func (em EventManager) streamError(error, desc string) {
+func (em *EventManager) streamError(error, desc string) {
 	em.CurrentState = StateStreamError
 	if em.Handler != nil {
 		em.Handler(Event{State: em.CurrentState, StreamError: error, Description: desc})

--- a/client_test.go
+++ b/client_test.go
@@ -19,6 +19,24 @@ const (
 	defaultTimeout = 2 * time.Second
 )
 
+func TestEventManager(t *testing.T) {
+	mgr := EventManager{}
+	mgr.updateState(StateConnected)
+	if mgr.CurrentState != StateConnected {
+		t.Fatal("CurrentState not updated by updateState()")
+	}
+
+	mgr.disconnected(SMState{})
+	if mgr.CurrentState != StateDisconnected {
+		t.Fatalf("CurrentState not reset by disconnected()")
+	}
+
+	mgr.streamError(ErrTLSNotSupported.Error(), "")
+	if mgr.CurrentState != StateStreamError {
+		t.Fatalf("CurrentState not set by streamError()")
+	}
+}
+
 func TestClient_Connect(t *testing.T) {
 	// Setup Mock server
 	mock := ServerMock{}


### PR DESCRIPTION
The EventManager methods did not use a pointer as receiver, which caused updates of CurrentState to be lost.