### PR TITLE
Result sets rework

### DIFF
--- a/_examples/custom_stanza/custom_stanza.go
+++ b/_examples/custom_stanza/custom_stanza.go
@@ -9,7 +9,10 @@ import (
 )
 
 func main() {
-	iq := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeGet, To: "service.localhost", Id: "custom-pl-1"})
+	iq, err := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeGet, To: "service.localhost", Id: "custom-pl-1"})
+	if err != nil {
+		log.Fatalf("failed to create IQ: %v", err)
+	}
 	payload := CustomPayload{XMLName: xml.Name{Space: "my:custom:payload", Local: "query"}, Node: "test"}
 	iq.Payload = payload
 
@@ -45,5 +48,5 @@ func (c CustomPayload) Namespace() string {
 }
 
 func init() {
-	stanza.TypeRegistry.MapExtension(stanza.PKTIQ, xml.Name{"my:custom:payload", "query"}, CustomPayload{})
+	stanza.TypeRegistry.MapExtension(stanza.PKTIQ, xml.Name{Space: "my:custom:payload", Local: "query"}, CustomPayload{})
 }

--- a/_examples/delegation/delegation.go
+++ b/_examples/delegation/delegation.go
@@ -35,7 +35,9 @@ func main() {
 		IQNamespaces("urn:xmpp:delegation:1").
 		HandlerFunc(handleDelegation)
 
-	component, err := xmpp.NewComponent(opts, router)
+	component, err := xmpp.NewComponent(opts, router, func(err error) {
+		log.Println(err)
+	})
 	if err != nil {
 		log.Fatalf("%+v", err)
 	}
@@ -78,7 +80,7 @@ const (
 // ctx.Opts
 func discoInfo(c xmpp.Sender, p stanza.Packet, opts xmpp.ComponentOptions) {
 	// Type conversion & sanity checks
-	iq, ok := p.(stanza.IQ)
+	iq, ok := p.(*stanza.IQ)
 	if !ok {
 		return
 	}
@@ -87,15 +89,18 @@ func discoInfo(c xmpp.Sender, p stanza.Packet, opts xmpp.ComponentOptions) {
 		return
 	}
 
-	iqResp := stanza.NewIQ(stanza.Attrs{Type: "result", From: iq.To, To: iq.From, Id: iq.Id})
+	iqResp, err := stanza.NewIQ(stanza.Attrs{Type: "result", From: iq.To, To: iq.From, Id: iq.Id})
+	if err != nil {
+		log.Fatalf("failed to create IQ response: %v", err)
+	}
 
 	switch info.Node {
 	case "":
-		discoInfoRoot(&iqResp, opts)
+		discoInfoRoot(iqResp, opts)
 	case pubsubNode:
-		discoInfoPubSub(&iqResp)
+		discoInfoPubSub(iqResp)
 	case pepNode:
-		discoInfoPEP(&iqResp)
+		discoInfoPEP(iqResp)
 	}
 
 	_ = c.Send(iqResp)
@@ -155,7 +160,7 @@ func discoInfoPEP(iqResp *stanza.IQ) {
 
 func handleDelegation(s xmpp.Sender, p stanza.Packet) {
 	// Type conversion & sanity checks
-	iq, ok := p.(stanza.IQ)
+	iq, ok := p.(*stanza.IQ)
 	if !ok {
 		return
 	}
@@ -166,7 +171,7 @@ func handleDelegation(s xmpp.Sender, p stanza.Packet) {
 	}
 	forwardedPacket := delegation.Forwarded.Stanza
 	fmt.Println(forwardedPacket)
-	forwardedIQ, ok := forwardedPacket.(stanza.IQ)
+	forwardedIQ, ok := forwardedPacket.(*stanza.IQ)
 	if !ok {
 		return
 	}
@@ -179,7 +184,10 @@ func handleDelegation(s xmpp.Sender, p stanza.Packet) {
 
 	if pubsub.Publish.XMLName.Local == "publish" {
 		// Prepare pubsub IQ reply
-		iqResp := stanza.NewIQ(stanza.Attrs{Type: "result", From: forwardedIQ.To, To: forwardedIQ.From, Id: forwardedIQ.Id})
+		iqResp, err := stanza.NewIQ(stanza.Attrs{Type: "result", From: forwardedIQ.To, To: forwardedIQ.From, Id: forwardedIQ.Id})
+		if err != nil {
+			log.Fatalf("failed to create iqResp: %v", err)
+		}
 		payload := stanza.PubSubGeneric{
 			XMLName: xml.Name{
 				Space: "http://jabber.org/protocol/pubsub",
@@ -188,7 +196,10 @@ func handleDelegation(s xmpp.Sender, p stanza.Packet) {
 		}
 		iqResp.Payload = &payload
 		// Wrap the reply in delegation 'forward'
-		iqForward := stanza.NewIQ(stanza.Attrs{Type: "result", From: iq.To, To: iq.From, Id: iq.Id})
+		iqForward, err := stanza.NewIQ(stanza.Attrs{Type: "result", From: iq.To, To: iq.From, Id: iq.Id})
+		if err != nil {
+			log.Fatalf("failed to create iqForward: %v", err)
+		}
 		delegPayload := stanza.Delegation{
 			XMLName: xml.Name{
 				Space: "urn:xmpp:delegation:1",

--- a/_examples/go.mod
+++ b/_examples/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/processone/mpg123 v1.0.0
 	github.com/processone/soundcloud v1.0.0
-	gosrc.io/xmpp v0.1.1
+	gosrc.io/xmpp v0.4.0
 )
 
 replace gosrc.io/xmpp => ./../

--- a/_examples/xmpp_chat_client/go.mod
+++ b/_examples/xmpp_chat_client/go.mod
@@ -6,5 +6,5 @@ require (
 	github.com/awesome-gocui/gocui v0.6.1-0.20191115151952-a34ffb055986
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.6.1
-	gosrc.io/xmpp v0.3.1-0.20191223080939-f8f820170e08
+	gosrc.io/xmpp v0.4.0
 )

--- a/_examples/xmpp_chat_client/xmpp_chat_client.go
+++ b/_examples/xmpp_chat_client/xmpp_chat_client.go
@@ -186,7 +186,7 @@ func startClient(g *gocui.Gui, config *config) {
 
 	// ==========================
 	// Start working
-	updateRosterFromConfig(g, config)
+	updateRosterFromConfig(config)
 	// Sending the default contact in a channel. Default value is the first contact in the list from the config.
 	viewState.currentContact = strings.Split(config.Contacts, configContactSep)[0]
 	// Informing user of the default contact
@@ -283,7 +283,7 @@ func errorHandler(err error) {
 
 // Read the client roster from the config. This does not check with the server that the roster is correct.
 // If user tries to send a message to someone not registered with the server, the server will return an error.
-func updateRosterFromConfig(g *gocui.Gui, config *config) {
+func updateRosterFromConfig(config *config) {
 	viewState.contacts = append(strings.Split(config.Contacts, configContactSep), backFromContacts)
 	// Put a "go back" button at the end of the list
 	viewState.contacts = append(viewState.contacts, backFromContacts)

--- a/_examples/xmpp_component/xmpp_component.go
+++ b/_examples/xmpp_component/xmpp_component.go
@@ -61,12 +61,16 @@ func handleMessage(_ xmpp.Sender, p stanza.Packet) {
 
 func discoInfo(c xmpp.Sender, p stanza.Packet, opts xmpp.ComponentOptions) {
 	// Type conversion & sanity checks
-	iq, ok := p.(stanza.IQ)
+	iq, ok := p.(*stanza.IQ)
 	if !ok || iq.Type != stanza.IQTypeGet {
 		return
 	}
 
-	iqResp := stanza.NewIQ(stanza.Attrs{Type: "result", From: iq.To, To: iq.From, Id: iq.Id, Lang: "en"})
+	iqResp, err := stanza.NewIQ(stanza.Attrs{Type: "result", From: iq.To, To: iq.From, Id: iq.Id, Lang: "en"})
+	// TODO: fix this...
+	if err != nil {
+		return
+	}
 	disco := iqResp.DiscoInfo()
 	disco.AddIdentity(opts.Name, opts.Category, opts.Type)
 	disco.AddFeatures(stanza.NSDiscoInfo, stanza.NSDiscoItems, "jabber:iq:version", "urn:xmpp:delegation:1")
@@ -76,7 +80,7 @@ func discoInfo(c xmpp.Sender, p stanza.Packet, opts xmpp.ComponentOptions) {
 // TODO: Handle iq error responses
 func discoItems(c xmpp.Sender, p stanza.Packet) {
 	// Type conversion & sanity checks
-	iq, ok := p.(stanza.IQ)
+	iq, ok := p.(*stanza.IQ)
 	if !ok || iq.Type != stanza.IQTypeGet {
 		return
 	}
@@ -86,7 +90,11 @@ func discoItems(c xmpp.Sender, p stanza.Packet) {
 		return
 	}
 
-	iqResp := stanza.NewIQ(stanza.Attrs{Type: "result", From: iq.To, To: iq.From, Id: iq.Id, Lang: "en"})
+	// TODO: fix this...
+	iqResp, err := stanza.NewIQ(stanza.Attrs{Type: "result", From: iq.To, To: iq.From, Id: iq.Id, Lang: "en"})
+	if err != nil {
+		return
+	}
 	items := iqResp.DiscoItems()
 
 	if discoItems.Node == "" {
@@ -97,12 +105,15 @@ func discoItems(c xmpp.Sender, p stanza.Packet) {
 
 func handleVersion(c xmpp.Sender, p stanza.Packet) {
 	// Type conversion & sanity checks
-	iq, ok := p.(stanza.IQ)
+	iq, ok := p.(*stanza.IQ)
 	if !ok {
 		return
 	}
 
-	iqResp := stanza.NewIQ(stanza.Attrs{Type: "result", From: iq.To, To: iq.From, Id: iq.Id, Lang: "en"})
+	iqResp, err := stanza.NewIQ(stanza.Attrs{Type: "result", From: iq.To, To: iq.From, Id: iq.Id, Lang: "en"})
+	if err != nil {
+		return
+	}
 	iqResp.Version().SetInfo("Fluux XMPP Component", "0.0.1", "")
 	_ = c.Send(iqResp)
 }

--- a/_examples/xmpp_component2/main.go
+++ b/_examples/xmpp_component2/main.go
@@ -9,9 +9,10 @@ Connect to an XMPP server using XEP 114 protocol, perform a discovery query on t
 import (
 	"context"
 	"fmt"
+	"log"
 	"time"
 
-	xmpp "gosrc.io/xmpp"
+	"gosrc.io/xmpp"
 	"gosrc.io/xmpp/stanza"
 )
 
@@ -53,10 +54,13 @@ func main() {
 	}
 
 	// make a disco iq
-	iqReq := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeGet,
+	iqReq, err := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeGet,
 		From: domain,
 		To:   "localhost",
 		Id:   "my-iq1"})
+	if err != nil {
+		log.Fatalf("failed to create IQ: %v", err)
+	}
 	disco := iqReq.DiscoInfo()
 	iqReq.Payload = disco
 

--- a/_examples/xmpp_jukebox/xmpp_jukebox.go
+++ b/_examples/xmpp_jukebox/xmpp_jukebox.go
@@ -81,7 +81,7 @@ func handleMessage(s xmpp.Sender, p stanza.Packet, player *mpg123.Player) {
 }
 
 func handleIQ(s xmpp.Sender, p stanza.Packet, player *mpg123.Player) {
-	iq, ok := p.(stanza.IQ)
+	iq, ok := p.(*stanza.IQ)
 	if !ok {
 		return
 	}
@@ -100,7 +100,7 @@ func handleIQ(s xmpp.Sender, p stanza.Packet, player *mpg123.Player) {
 		setResponse := new(stanza.ControlSetResponse)
 		// FIXME: Broken
 		reply := stanza.IQ{Attrs: stanza.Attrs{To: iq.From, Type: "result", Id: iq.Id}, Payload: setResponse}
-		_ = s.Send(reply)
+		_ = s.Send(&reply)
 		// TODO add Soundclound artist / title retrieval
 		sendUserTune(s, "Radiohead", "Spectre")
 	default:

--- a/bi_dir_iterator.go
+++ b/bi_dir_iterator.go
@@ -1,0 +1,12 @@
+package xmpp
+
+type BiDirIterator interface {
+	// Next returns the next element of this iterator, if a response is available within t milliseconds
+	Next(t int) (BiDirIteratorElt, error)
+	// Previous returns the previous element of this iterator, if a response is available within t milliseconds
+	Previous(t int) (BiDirIteratorElt, error)
+}
+
+type BiDirIteratorElt interface {
+	NoOp()
+}

--- a/client.go
+++ b/client.go
@@ -264,7 +264,7 @@ func (c *Client) Send(packet stanza.Packet) error {
 //   ctx, _ := context.WithTimeout(context.Background(), 30 * time.Second)
 //   result := <- client.SendIQ(ctx, iq)
 //
-func (c *Client) SendIQ(ctx context.Context, iq stanza.IQ) (chan stanza.IQ, error) {
+func (c *Client) SendIQ(ctx context.Context, iq *stanza.IQ) (chan stanza.IQ, error) {
 	if iq.Attrs.Type != stanza.IQTypeSet && iq.Attrs.Type != stanza.IQTypeGet {
 		return nil, ErrCanOnlySendGetOrSetIq
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -171,7 +171,11 @@ func TestClient_SendIQ(t *testing.T) {
 	client, mock := mockClientConnection(t, h, testClientIqPort)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	iqReq := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeGet, From: "test1@localhost/mremond-mbp", To: defaultServerName, Id: defaultStreamID, Lang: "en"})
+	iqReq, err := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeGet, From: "test1@localhost/mremond-mbp", To: defaultServerName, Id: defaultStreamID, Lang: "en"})
+	if err != nil {
+		t.Fatalf("failed to create the IQ request: %v", err)
+	}
+
 	disco := iqReq.DiscoInfo()
 	iqReq.Payload = disco
 
@@ -219,7 +223,10 @@ func TestClient_SendIQFail(t *testing.T) {
 	//==================
 	// Create an IQ to send
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	iqReq := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeGet, From: "test1@localhost/mremond-mbp", To: defaultServerName, Id: defaultStreamID, Lang: "en"})
+	iqReq, err := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeGet, From: "test1@localhost/mremond-mbp", To: defaultServerName, Id: defaultStreamID, Lang: "en"})
+	if err != nil {
+		t.Fatalf("failed to create IQ request: %v", err)
+	}
 	disco := iqReq.DiscoInfo()
 	iqReq.Payload = disco
 	// Removing the id to make the stanza invalid. The IQ constructor makes a random one if none is specified
@@ -387,7 +394,7 @@ func handlerClientConnectSuccess(t *testing.T, sc *ServerConn) {
 	checkClientOpenStream(t, sc)
 	sendStreamFeatures(t, sc) // Send initial features
 	readAuth(t, sc.decoder)
-	fmt.Fprintln(sc.connection, "<success xmlns=\"urn:ietf:params:xml:ns:xmpp-sasl\"/>")
+	sc.connection.Write([]byte("<success xmlns=\"urn:ietf:params:xml:ns:xmpp-sasl\"/>"))
 
 	checkClientOpenStream(t, sc) // Reset stream
 	sendBindFeature(t, sc)       // Send post auth features

--- a/cmd/fluuxmpp/send.go
+++ b/cmd/fluuxmpp/send.go
@@ -38,7 +38,11 @@ func sendxmpp(cmd *cobra.Command, args []string) {
 		},
 		Jid:        viper.GetString("jid"),
 		Credential: xmpp.Password(viper.GetString("password")),
-	}, xmpp.NewRouter())
+	},
+		xmpp.NewRouter(),
+		func(err error) {
+			log.Println(err)
+		})
 
 	if err != nil {
 		log.Errorf("error when starting xmpp client: %s", err)

--- a/component.go
+++ b/component.go
@@ -185,7 +185,7 @@ func (c *Component) sendWithWriter(writer io.Writer, packet []byte) error {
 //   ctx, _ := context.WithTimeout(context.Background(), 30 * time.Second)
 //   result := <- client.SendIQ(ctx, iq)
 //
-func (c *Component) SendIQ(ctx context.Context, iq stanza.IQ) (chan stanza.IQ, error) {
+func (c *Component) SendIQ(ctx context.Context, iq *stanza.IQ) (chan stanza.IQ, error) {
 	if iq.Attrs.Type != stanza.IQTypeSet && iq.Attrs.Type != stanza.IQTypeGet {
 		return nil, ErrCanOnlySendGetOrSetIq
 	}

--- a/component_test.go
+++ b/component_test.go
@@ -93,7 +93,7 @@ func TestGenerateHandshakeId(t *testing.T) {
 
 	// Try connecting, and storing the resulting streamID in a map.
 	m := make(map[string]bool)
-	for _, _ = range uuidsArray {
+	for range uuidsArray {
 		streamId, _ := c.transport.Connect()
 		m[c.handshake(streamId)] = true
 	}
@@ -131,7 +131,10 @@ func TestSendIq(t *testing.T) {
 	c, m := mockComponentConnection(t, testSendIqPort, h)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	iqReq := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeGet, From: "test1@localhost/mremond-mbp", To: defaultServerName, Id: defaultStreamID, Lang: "en"})
+	iqReq, err := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeGet, From: "test1@localhost/mremond-mbp", To: defaultServerName, Id: defaultStreamID, Lang: "en"})
+	if err != nil {
+		t.Fatalf("failed to create IQ request: %v", err)
+	}
 	disco := iqReq.DiscoInfo()
 	iqReq.Payload = disco
 
@@ -173,7 +176,10 @@ func TestSendIqFail(t *testing.T) {
 	c, m := mockComponentConnection(t, testSendIqFailPort, h)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	iqReq := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeGet, From: "test1@localhost/mremond-mbp", To: defaultServerName, Id: defaultStreamID, Lang: "en"})
+	iqReq, err := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeGet, From: "test1@localhost/mremond-mbp", To: defaultServerName, Id: defaultStreamID, Lang: "en"})
+	if err != nil {
+		t.Fatalf("failed to create IQ request: %v", err)
+	}
 
 	// Removing the id to make the stanza invalid. The IQ constructor makes a random one if none is specified
 	// so we need to overwrite it.

--- a/router_test.go
+++ b/router_test.go
@@ -25,7 +25,10 @@ func TestIQResultRoutes(t *testing.T) {
 	// Check if the IQ handler was called
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*100)
 	defer cancel()
-	iq := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeResult, Id: "1234"})
+	iq, err := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeResult, Id: "1234"})
+	if err != nil {
+		t.Fatalf("failed to create IQ: %v", err)
+	}
 	res := router.NewIQResultRoute(ctx, "1234")
 	go router.route(conn, iq)
 	select {
@@ -71,7 +74,10 @@ func TestNameMatcher(t *testing.T) {
 
 	// Check that an IQ packet is not matched
 	conn = NewSenderMock()
-	iq := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeGet, To: "localhost", Id: "1"})
+	iq, err := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeGet, To: "localhost", Id: "1"})
+	if err != nil {
+		t.Fatalf("failed to create IQ: %v", err)
+	}
 	iq.Payload = &stanza.DiscoInfo{}
 	router.route(conn, iq)
 	if conn.String() == successFlag {
@@ -89,7 +95,10 @@ func TestIQNSMatcher(t *testing.T) {
 
 	// Check that an IQ with proper namespace does match
 	conn := NewSenderMock()
-	iqDisco := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeGet, To: "localhost", Id: "1"})
+	iqDisco, err := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeGet, To: "localhost", Id: "1"})
+	if err != nil {
+		t.Fatalf("failed to create iqDisco: %v", err)
+	}
 	// TODO: Add a function to generate payload with proper namespace initialisation
 	iqDisco.Payload = &stanza.DiscoInfo{
 		XMLName: xml.Name{
@@ -103,7 +112,10 @@ func TestIQNSMatcher(t *testing.T) {
 
 	// Check that another namespace is not matched
 	conn = NewSenderMock()
-	iqVersion := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeGet, To: "localhost", Id: "1"})
+	iqVersion, err := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeGet, To: "localhost", Id: "1"})
+	if err != nil {
+		t.Fatalf("failed to create iqVersion: %v", err)
+	}
 	// TODO: Add a function to generate payload with proper namespace initialisation
 	iqVersion.Payload = &stanza.DiscoInfo{
 		XMLName: xml.Name{
@@ -146,7 +158,10 @@ func TestTypeMatcher(t *testing.T) {
 
 	// We do not match on other types
 	conn = NewSenderMock()
-	iqVersion := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeGet, From: "service.localhost", To: "test@localhost", Id: "1"})
+	iqVersion, err := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeGet, From: "service.localhost", To: "test@localhost", Id: "1"})
+	if err != nil {
+		t.Fatalf("failed to create iqVersion: %v", err)
+	}
 	iqVersion.Payload = &stanza.DiscoInfo{
 		XMLName: xml.Name{
 			Space: "jabber:iq:version",
@@ -169,22 +184,31 @@ func TestCompositeMatcher(t *testing.T) {
 		})
 
 	// Data set
-	getVersionIq := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeGet, From: "service.localhost", To: "test@localhost", Id: "1"})
+	getVersionIq, err := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeGet, From: "service.localhost", To: "test@localhost", Id: "1"})
+	if err != nil {
+		t.Fatalf("failed to create getVersionIq: %v", err)
+	}
 	getVersionIq.Payload = &stanza.Version{
 		XMLName: xml.Name{
 			Space: "jabber:iq:version",
 			Local: "query",
 		}}
 
-	setVersionIq := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeSet, From: "service.localhost", To: "test@localhost", Id: "1"})
+	setVersionIq, err := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeSet, From: "service.localhost", To: "test@localhost", Id: "1"})
+	if err != nil {
+		t.Fatalf("failed to create setVersionIq: %v", err)
+	}
 	setVersionIq.Payload = &stanza.Version{
 		XMLName: xml.Name{
 			Space: "jabber:iq:version",
 			Local: "query",
 		}}
 
-	GetDiscoIq := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeGet, From: "service.localhost", To: "test@localhost", Id: "1"})
-	GetDiscoIq.Payload = &stanza.DiscoInfo{
+	getDiscoIq, err := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeGet, From: "service.localhost", To: "test@localhost", Id: "1"})
+	if err != nil {
+		t.Fatalf("failed to create getDiscoIq: %v", err)
+	}
+	getDiscoIq.Payload = &stanza.DiscoInfo{
 		XMLName: xml.Name{
 			Space: "http://jabber.org/protocol/disco#info",
 			Local: "query",
@@ -200,7 +224,7 @@ func TestCompositeMatcher(t *testing.T) {
 	}{
 		{name: "match get version iq", input: getVersionIq, want: true},
 		{name: "ignore set version iq", input: setVersionIq, want: false},
-		{name: "ignore get discoinfo iq", input: GetDiscoIq, want: false},
+		{name: "ignore get discoinfo iq", input: getDiscoIq, want: false},
 		{name: "ignore message", input: message, want: false},
 	}
 
@@ -238,7 +262,10 @@ func TestCatchallMatcher(t *testing.T) {
 	}
 
 	conn = NewSenderMock()
-	iqVersion := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeGet, From: "service.localhost", To: "test@localhost", Id: "1"})
+	iqVersion, err := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeGet, From: "service.localhost", To: "test@localhost", Id: "1"})
+	if err != nil {
+		t.Fatalf("failed to create iqVersion: %v", err)
+	}
 	iqVersion.Payload = &stanza.DiscoInfo{
 		XMLName: xml.Name{
 			Space: "jabber:iq:version",
@@ -274,7 +301,7 @@ func (s SenderMock) Send(packet stanza.Packet) error {
 	return nil
 }
 
-func (s SenderMock) SendIQ(ctx context.Context, iq stanza.IQ) (chan stanza.IQ, error) {
+func (s SenderMock) SendIQ(ctx context.Context, iq *stanza.IQ) (chan stanza.IQ, error) {
 	out, err := xml.Marshal(iq)
 	if err != nil {
 		return nil, err

--- a/session.go
+++ b/session.go
@@ -97,7 +97,7 @@ func (s *Session) startTlsIfSupported(o Config) {
 
 	if !s.transport.DoesStartTLS() {
 		if !o.Insecure {
-			s.err = errors.New("Transport does not support starttls")
+			s.err = errors.New("transport does not support starttls")
 		}
 		return
 	}

--- a/stanza/commands.go
+++ b/stanza/commands.go
@@ -23,7 +23,7 @@ const (
 type Command struct {
 	XMLName xml.Name `xml:"http://jabber.org/protocol/commands command"`
 
-	CommandElement CommandElement `xml:",any"`
+	CommandElement CommandElement
 
 	BadAction       *struct{} `xml:"bad-action,omitempty"`
 	BadLocale       *struct{} `xml:"bad-locale,omitempty"`
@@ -38,10 +38,17 @@ type Command struct {
 	SessionId string `xml:"sessionid,attr,omitempty"`
 	Status    string `xml:"status,attr,omitempty"`
 	Lang      string `xml:"lang,attr,omitempty"`
+
+	// Result sets
+	ResultSet *ResultSet `xml:"set,omitempty"`
 }
 
 func (c *Command) Namespace() string {
 	return c.XMLName.Space
+}
+
+func (c *Command) GetSet() *ResultSet {
+	return c.ResultSet
 }
 
 type CommandElement interface {
@@ -68,6 +75,7 @@ type Note struct {
 func (n *Note) Ref() string {
 	return "note"
 }
+func (f *Form) Ref() string { return "form" }
 
 func (n *Node) Ref() string {
 	return "node"
@@ -117,6 +125,10 @@ func (c *Command) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 				nt := Note{}
 				d.DecodeElement(&nt, &tt)
 				c.CommandElement = &nt
+			case "x":
+				f := Form{}
+				d.DecodeElement(&f, &tt)
+				c.CommandElement = &f
 			default:
 				n := Node{}
 				e := d.DecodeElement(&n, &tt)
@@ -133,4 +145,8 @@ func (c *Command) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 			}
 		}
 	}
+}
+
+func init() {
+	TypeRegistry.MapExtension(PKTIQ, xml.Name{Space: "http://jabber.org/protocol/commands", Local: "command"}, Command{})
 }

--- a/stanza/commands_test.go
+++ b/stanza/commands_test.go
@@ -7,34 +7,21 @@ import (
 )
 
 func TestMarshalCommands(t *testing.T) {
-	input := "<command xmlns=\"http://jabber.org/protocol/commands\" node=\"list\" sessionid=\"list:20020923T213616Z-700\" status=\"completed\"><x " +
-		"xmlns=\"jabber:x:data\" type=\"result\"><title xmlns=\"jabber:x:data\">Available Servi" +
-		"ces</title><reported xmlns=\"jabber:x:data\"><field xmlns=\"jabber:x:data\" label=\"S" +
-		"ervice\" var=\"service\"></field><field xmlns=\"jabber:x:data\" label=\"Single-User mo" +
-		"de\" var=\"runlevel-1\"></field><field xmlns=\"jabber:x:data\" label=\"Non-Networked M" +
-		"ulti-User mode\" var=\"runlevel-2\"></field><field xmlns=\"jabber:x:data\" label=\"Ful" +
-		"l Multi-User mode\" var=\"runlevel-3\"></field><field xmlns=\"jabber:x:data\" label=\"" +
-		"X-Window mode\" var=\"runlevel-5\"></field></reported><item xmlns=\"jabber:x:data\"><" +
-		"field xmlns=\"jabber:x:data\" var=\"service\"><value xmlns=\"jabber:x:data\">httpd</va" +
-		"lue></field><field xmlns=\"jabber:x:data\" var=\"runlevel-1\"><value xmlns=\"jabber:x" +
-		":data\">off</value></field><field xmlns=\"jabber:x:data\" var=\"runlevel-2\"><value x" +
-		"mlns=\"jabber:x:data\">off</value></field><field xmlns=\"jabber:x:data\" var=\"runlev" +
-		"el-3\"><value xmlns=\"jabber:x:data\">on</value></field><field xmlns=\"jabber:x:data" +
-		"\" var=\"runlevel-5\"><value xmlns=\"jabber:x:data\">on</value></field></item><item x" +
-		"mlns=\"jabber:x:data\"><field xmlns=\"jabber:x:data\" var=\"service\"><value xmlns=\"ja" +
-		"bber:x:data\">postgresql</value></field><field xmlns=\"jabber:x:data\" var=\"runleve" +
-		"l-1\"><value xmlns=\"jabber:x:data\">off</value></field><field xmlns=\"jabber:x:data" +
-		"\" var=\"runlevel-2\"><value xmlns=\"jabber:x:data\">off</value></field><field xmlns=" +
-		"\"jabber:x:data\" var=\"runlevel-3\"><value xmlns=\"jabber:x:data\">on</value></field>" +
-		"<field xmlns=\"jabber:x:data\" var=\"runlevel-5\"><value xmlns=\"jabber:x:data\">on</v" +
-		"alue></field></item><item xmlns=\"jabber:x:data\"><field xmlns=\"jabber:x:data\" var" +
-		"=\"service\"><value xmlns=\"jabber:x:data\">jabberd</value></field><field xmlns=\"jab" +
-		"ber:x:data\" var=\"runlevel-1\"><value xmlns=\"jabber:x:data\">off</value></field><fi" +
-		"eld xmlns=\"jabber:x:data\" var=\"runlevel-2\"><value xmlns=\"jabber:x:data\">off</val" +
-		"ue></field><field xmlns=\"jabber:x:data\" var=\"runlevel-3\"><value xmlns=\"jabber:x:" +
-		"data\">on</value></field><field xmlns=\"jabber:x:data\" var=\"runlevel-5\"><value xml" +
-		"ns=\"jabber:x:data\">on</value></field></item></x></command>"
-
+	input := "<command xmlns=\"http://jabber.org/protocol/commands\" node=\"list\" " +
+		"sessionid=\"list:20020923T213616Z-700\" status=\"completed\"><x xmlns=\"jabber:x:data\" " +
+		"type=\"result\"><title>Available Services</title><reported xmlns=\"jabber:x:data\"><field var=\"service\" " +
+		"label=\"Service\"></field><field var=\"runlevel-1\" label=\"Single-User mode\">" +
+		"</field><field var=\"runlevel-2\" label=\"Non-Networked Multi-User mode\"></field><field var=\"runlevel-3\" " +
+		"label=\"Full Multi-User mode\"></field><field var=\"runlevel-5\" label=\"X-Window mode\"></field></reported>" +
+		"<item xmlns=\"jabber:x:data\"><field var=\"service\"><value>httpd</value></field><field var=\"runlevel-1\">" +
+		"<value>off</value></field><field var=\"runlevel-2\"><value>off</value></field><field var=\"runlevel-3\">" +
+		"<value>on</value></field><field var=\"runlevel-5\"><value>on</value></field></item>" +
+		"<item xmlns=\"jabber:x:data\"><field var=\"service\"><value>postgresql</value></field>" +
+		"<field var=\"runlevel-1\"><value>off</value></field><field var=\"runlevel-2\"><value>off</value></field>" +
+		"<field var=\"runlevel-3\"><value>on</value></field><field var=\"runlevel-5\"><value>on</value></field></item>" +
+		"<item xmlns=\"jabber:x:data\"><field var=\"service\"><value>jabberd</value></field><field var=\"runlevel-1\">" +
+		"<value>off</value></field><field var=\"runlevel-2\"><value>off</value></field><field var=\"runlevel-3\">" +
+		"<value>on</value></field><field var=\"runlevel-5\"><value>on</value></field></item></x></command>"
 	var c stanza.Command
 	err := xml.Unmarshal([]byte(input), &c)
 

--- a/stanza/component.go
+++ b/stanza/component.go
@@ -42,10 +42,15 @@ type Delegation struct {
 	XMLName   xml.Name   `xml:"urn:xmpp:delegation:1 delegation"`
 	Forwarded *Forwarded // This is used in iq to wrap delegated iqs
 	Delegated *Delegated // This is used in a message to confirm delegated namespace
+	// Result sets
+	ResultSet *ResultSet `xml:"set,omitempty"`
 }
 
 func (d *Delegation) Namespace() string {
 	return d.XMLName.Space
+}
+func (d *Delegation) GetSet() *ResultSet {
+	return d.ResultSet
 }
 
 // Forwarded is used to wrapped forwarded stanzas.
@@ -86,6 +91,6 @@ type Delegated struct {
 }
 
 func init() {
-	TypeRegistry.MapExtension(PKTMessage, xml.Name{"urn:xmpp:delegation:1", "delegation"}, Delegation{})
-	TypeRegistry.MapExtension(PKTIQ, xml.Name{"urn:xmpp:delegation:1", "delegation"}, Delegation{})
+	TypeRegistry.MapExtension(PKTMessage, xml.Name{Space: "urn:xmpp:delegation:1", Local: "delegation"}, Delegation{})
+	TypeRegistry.MapExtension(PKTIQ, xml.Name{Space: "urn:xmpp:delegation:1", Local: "delegation"}, Delegation{})
 }

--- a/stanza/component_test.go
+++ b/stanza/component_test.go
@@ -61,7 +61,7 @@ func TestParsingDelegationIQ(t *testing.T) {
 	if iq.Payload != nil {
 		if delegation, ok := iq.Payload.(*Delegation); ok {
 			packet := delegation.Forwarded.Stanza
-			forwardedIQ, ok := packet.(IQ)
+			forwardedIQ, ok := packet.(*IQ)
 			if !ok {
 				t.Errorf("Could not extract packet IQ")
 				return

--- a/stanza/form.go
+++ b/stanza/form.go
@@ -14,17 +14,18 @@ const (
 // See XEP-0004 and XEP-0068
 // Pointer semantics
 type Form struct {
-	XMLName      xml.Name  `xml:"jabber:x:data x"`
-	Instructions []string  `xml:"instructions"`
-	Title        string    `xml:"title,omitempty"`
-	Fields       []*Field  `xml:"field,omitempty"`
-	Reported     *FormItem `xml:"reported"`
-	Items        []FormItem
-	Type         string `xml:"type,attr"`
+	XMLName      xml.Name   `xml:"jabber:x:data x"`
+	Instructions []string   `xml:"instructions"`
+	Title        string     `xml:"title,omitempty"`
+	Fields       []*Field   `xml:"field,omitempty"`
+	Reported     *FormItem  `xml:"reported"`
+	Items        []FormItem `xml:"item,omitempty"`
+	Type         string     `xml:"type,attr"`
 }
 
 type FormItem struct {
-	Fields []Field
+	XMLName xml.Name
+	Fields  []Field `xml:"field,omitempty"`
 }
 
 type Field struct {

--- a/stanza/form_test.go
+++ b/stanza/form_test.go
@@ -51,7 +51,10 @@ const (
 )
 
 func TestMarshalFormSubmit(t *testing.T) {
-	formIQ := NewIQ(Attrs{From: clientJid, To: serviceJid, Id: iqId, Type: IQTypeSet})
+	formIQ, err := NewIQ(Attrs{From: clientJid, To: serviceJid, Id: iqId, Type: IQTypeSet})
+	if err != nil {
+		t.Fatalf("failed to create formIQ: %v", err)
+	}
 	formIQ.Payload = &PubSubOwner{
 		OwnerUseCase: &ConfigureOwner{
 			Node: serviceNode,

--- a/stanza/iot.go
+++ b/stanza/iot.go
@@ -7,10 +7,16 @@ import (
 type ControlSet struct {
 	XMLName xml.Name       `xml:"urn:xmpp:iot:control set"`
 	Fields  []ControlField `xml:",any"`
+	// Result sets
+	ResultSet *ResultSet `xml:"set,omitempty"`
 }
 
 func (c *ControlSet) Namespace() string {
 	return c.XMLName.Space
+}
+
+func (c *ControlSet) GetSet() *ResultSet {
+	return c.ResultSet
 }
 
 type ControlGetForm struct {
@@ -30,10 +36,13 @@ type ControlSetResponse struct {
 func (c *ControlSetResponse) Namespace() string {
 	return c.XMLName.Space
 }
+func (c *ControlSetResponse) GetSet() *ResultSet {
+	return nil
+}
 
 // ============================================================================
 // Registry init
 
 func init() {
-	TypeRegistry.MapExtension(PKTIQ, xml.Name{"urn:xmpp:iot:control", "set"}, ControlSet{})
+	TypeRegistry.MapExtension(PKTIQ, xml.Name{Space: "urn:xmpp:iot:control", Local: "set"}, ControlSet{})
 }

--- a/stanza/iq_disco.go
+++ b/stanza/iq_disco.go
@@ -16,15 +16,20 @@ const (
 // Namespaces
 
 type DiscoInfo struct {
-	XMLName  xml.Name   `xml:"http://jabber.org/protocol/disco#info query"`
-	Node     string     `xml:"node,attr,omitempty"`
-	Identity []Identity `xml:"identity"`
-	Features []Feature  `xml:"feature"`
+	XMLName   xml.Name   `xml:"http://jabber.org/protocol/disco#info query"`
+	Node      string     `xml:"node,attr,omitempty"`
+	Identity  []Identity `xml:"identity"`
+	Features  []Feature  `xml:"feature"`
+	ResultSet *ResultSet `xml:"set,omitempty"`
 }
 
 // Namespace lets DiscoInfo implement the IQPayload interface
 func (d *DiscoInfo) Namespace() string {
 	return d.XMLName.Space
+}
+
+func (d *DiscoInfo) GetSet() *ResultSet {
+	return d.ResultSet
 }
 
 // ---------------
@@ -102,10 +107,17 @@ type DiscoItems struct {
 	XMLName xml.Name    `xml:"http://jabber.org/protocol/disco#items query"`
 	Node    string      `xml:"node,attr,omitempty"`
 	Items   []DiscoItem `xml:"item"`
+
+	// Result sets
+	ResultSet *ResultSet `xml:"set,omitempty"`
 }
 
 func (d *DiscoItems) Namespace() string {
 	return d.XMLName.Space
+}
+
+func (d *DiscoItems) GetSet() *ResultSet {
+	return d.ResultSet
 }
 
 // ---------------
@@ -146,6 +158,6 @@ type DiscoItem struct {
 // Registry init
 
 func init() {
-	TypeRegistry.MapExtension(PKTIQ, xml.Name{NSDiscoInfo, "query"}, DiscoInfo{})
-	TypeRegistry.MapExtension(PKTIQ, xml.Name{NSDiscoItems, "query"}, DiscoItems{})
+	TypeRegistry.MapExtension(PKTIQ, xml.Name{Space: NSDiscoInfo, Local: "query"}, DiscoInfo{})
+	TypeRegistry.MapExtension(PKTIQ, xml.Name{Space: NSDiscoItems, Local: "query"}, DiscoItems{})
 }

--- a/stanza/iq_disco_test.go
+++ b/stanza/iq_disco_test.go
@@ -9,7 +9,10 @@ import (
 
 // Test DiscoInfo Builder with several features
 func TestDiscoInfo_Builder(t *testing.T) {
-	iq := stanza.NewIQ(stanza.Attrs{Type: "get", To: "service.localhost", Id: "disco-get-1"})
+	iq, err := stanza.NewIQ(stanza.Attrs{Type: "get", To: "service.localhost", Id: "disco-get-1"})
+	if err != nil {
+		t.Fatalf("failed to create IQ: %v", err)
+	}
 	disco := iq.DiscoInfo()
 	disco.AddIdentity("Test Component", "gateway", "service")
 	disco.AddFeatures(stanza.NSDiscoInfo, stanza.NSDiscoItems, "jabber:iq:version", "urn:xmpp:delegation:1")
@@ -50,8 +53,11 @@ func TestDiscoInfo_Builder(t *testing.T) {
 // Implements XEP-0030 example 17
 // https://xmpp.org/extensions/xep-0030.html#example-17
 func TestDiscoItems_Builder(t *testing.T) {
-	iq := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeResult, From: "catalog.shakespeare.lit",
+	iq, err := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeResult, From: "catalog.shakespeare.lit",
 		To: "romeo@montague.net/orchard", Id: "items-2"})
+	if err != nil {
+		t.Fatalf("failed to create IQ: %v", err)
+	}
 	iq.DiscoItems().
 		AddItem("catalog.shakespeare.lit", "books", "Books by and about Shakespeare").
 		AddItem("catalog.shakespeare.lit", "clothing", "Wear your literary taste with pride").

--- a/stanza/iq_roster.go
+++ b/stanza/iq_roster.go
@@ -35,11 +35,16 @@ const (
 // Roster struct represents Roster IQs
 type Roster struct {
 	XMLName xml.Name `xml:"jabber:iq:roster query"`
+	// Result sets
+	ResultSet *ResultSet `xml:"set,omitempty"`
 }
 
 // Namespace defines the namespace for the RosterIQ
 func (r *Roster) Namespace() string {
 	return r.XMLName.Space
+}
+func (r *Roster) GetSet() *ResultSet {
+	return r.ResultSet
 }
 
 // ---------------
@@ -64,11 +69,17 @@ func (iq *IQ) RosterIQ() *Roster {
 type RosterItems struct {
 	XMLName xml.Name     `xml:"jabber:iq:roster query"`
 	Items   []RosterItem `xml:"item"`
+	// Result sets
+	ResultSet *ResultSet `xml:"set,omitempty"`
 }
 
 // Namespace lets RosterItems implement the IQPayload interface
 func (r *RosterItems) Namespace() string {
 	return r.XMLName.Space
+}
+
+func (r *RosterItems) GetSet() *ResultSet {
+	return r.ResultSet
 }
 
 // RosterItem represents an item in the roster iq

--- a/stanza/iq_roster_test.go
+++ b/stanza/iq_roster_test.go
@@ -7,7 +7,10 @@ import (
 )
 
 func TestRosterBuilder(t *testing.T) {
-	iq := NewIQ(Attrs{Type: IQTypeResult, From: "romeo@montague.net/orchard"})
+	iq, err := NewIQ(Attrs{Type: IQTypeResult, From: "romeo@montague.net/orchard"})
+	if err != nil {
+		t.Fatalf("failed to create IQ: %v", err)
+	}
 	var noGroup []string
 
 	iq.RosterItems().AddItem("xl8ceawrfu8zdneomw1h6h28d@crypho.com",
@@ -91,7 +94,7 @@ func TestRosterBuilder(t *testing.T) {
 	}
 }
 
-func checkMarshalling(t *testing.T, iq IQ) (*IQ, error) {
+func checkMarshalling(t *testing.T, iq *IQ) (*IQ, error) {
 	// Marshall
 	data, err := xml.Marshal(iq)
 	if err != nil {

--- a/stanza/iq_test.go
+++ b/stanza/iq_test.go
@@ -36,24 +36,36 @@ func TestUnmarshalIqs(t *testing.T) {
 
 func TestGenerateIqId(t *testing.T) {
 	t.Parallel()
-	iq := stanza.NewIQ(stanza.Attrs{Id: "1"})
+	iq, err := stanza.NewIQ(stanza.Attrs{Id: "1", Type: "dummy type"})
+	if err != nil {
+		t.Fatalf("failed to create IQ: %v", err)
+	}
 	if iq.Id != "1" {
 		t.Errorf("NewIQ replaced id with %s", iq.Id)
 	}
 
-	iq = stanza.NewIQ(stanza.Attrs{})
+	iq, err = stanza.NewIQ(stanza.Attrs{Type: "dummy type"})
+	if err != nil {
+		t.Fatalf("failed to create IQ: %v", err)
+	}
 	if iq.Id == "" {
 		t.Error("NewIQ did not generate an Id")
 	}
 
-	otherIq := stanza.NewIQ(stanza.Attrs{})
+	otherIq, err := stanza.NewIQ(stanza.Attrs{Type: "dummy type"})
+	if err != nil {
+		t.Fatalf("failed to create IQ: %v", err)
+	}
 	if iq.Id == otherIq.Id {
 		t.Errorf("NewIQ generated two identical ids: %s", iq.Id)
 	}
 }
 
 func TestGenerateIq(t *testing.T) {
-	iq := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeResult, From: "admin@localhost", To: "test@localhost", Id: "1"})
+	iq, err := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeResult, From: "admin@localhost", To: "test@localhost", Id: "1"})
+	if err != nil {
+		t.Fatalf("failed to create IQ: %v", err)
+	}
 	payload := stanza.DiscoInfo{
 		Identity: []stanza.Identity{
 			{Name: "Test Gateway",
@@ -111,7 +123,10 @@ func TestErrorTag(t *testing.T) {
 }
 
 func TestDiscoItems(t *testing.T) {
-	iq := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeGet, From: "romeo@montague.net/orchard", To: "catalog.shakespeare.lit", Id: "items3"})
+	iq, err := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeGet, From: "romeo@montague.net/orchard", To: "catalog.shakespeare.lit", Id: "items3"})
+	if err != nil {
+		t.Fatalf("failed to create IQ: %v", err)
+	}
 	payload := stanza.DiscoItems{
 		Node: "music",
 	}
@@ -215,8 +230,9 @@ func TestIsValid(t *testing.T) {
 				t.Errorf("Unmarshal error: %#v (%s)", err, tcase.iq)
 				return
 			}
-			if !parsedIQ.IsValid() && !tcase.shouldErr {
-				t.Errorf("failed iq validation for : %s", tcase.iq)
+			isValid, err := parsedIQ.IsValid()
+			if !isValid && !tcase.shouldErr {
+				t.Errorf("failed validation for iq because: %s\nin test case : %s", err, tcase.iq)
 			}
 		})
 	}

--- a/stanza/iq_version.go
+++ b/stanza/iq_version.go
@@ -11,10 +11,16 @@ type Version struct {
 	Name    string   `xml:"name,omitempty"`
 	Version string   `xml:"version,omitempty"`
 	OS      string   `xml:"os,omitempty"`
+	// Result sets
+	ResultSet *ResultSet `xml:"set,omitempty"`
 }
 
 func (v *Version) Namespace() string {
 	return v.XMLName.Space
+}
+
+func (v *Version) GetSet() *ResultSet {
+	return v.ResultSet
 }
 
 // ---------------
@@ -41,5 +47,5 @@ func (v *Version) SetInfo(name, version, os string) *Version {
 // Registry init
 
 func init() {
-	TypeRegistry.MapExtension(PKTIQ, xml.Name{"jabber:iq:version", "query"}, Version{})
+	TypeRegistry.MapExtension(PKTIQ, xml.Name{Space: "jabber:iq:version", Local: "query"}, Version{})
 }

--- a/stanza/iq_version_test.go
+++ b/stanza/iq_version_test.go
@@ -12,8 +12,11 @@ func TestVersion_Builder(t *testing.T) {
 	name := "Exodus"
 	version := "0.7.0.4"
 	os := "Windows-XP 5.01.2600"
-	iq := stanza.NewIQ(stanza.Attrs{Type: "result", From: "romeo@montague.net/orchard",
+	iq, err := stanza.NewIQ(stanza.Attrs{Type: "result", From: "romeo@montague.net/orchard",
 		To: "juliet@capulet.com/balcony", Id: "version_1"})
+	if err != nil {
+		t.Fatalf("failed to create IQ: %v", err)
+	}
 	iq.Version().SetInfo(name, version, os)
 
 	parsedIQ, err := checkMarshalling(t, iq)

--- a/stanza/msg_chat_markers.go
+++ b/stanza/msg_chat_markers.go
@@ -35,8 +35,8 @@ type MarkAcknowledged struct {
 }
 
 func init() {
-	TypeRegistry.MapExtension(PKTMessage, xml.Name{NSMsgChatMarkers, "markable"}, Markable{})
-	TypeRegistry.MapExtension(PKTMessage, xml.Name{NSMsgChatMarkers, "received"}, MarkReceived{})
-	TypeRegistry.MapExtension(PKTMessage, xml.Name{NSMsgChatMarkers, "displayed"}, MarkDisplayed{})
-	TypeRegistry.MapExtension(PKTMessage, xml.Name{NSMsgChatMarkers, "acknowledged"}, MarkAcknowledged{})
+	TypeRegistry.MapExtension(PKTMessage, xml.Name{Space: NSMsgChatMarkers, Local: "markable"}, Markable{})
+	TypeRegistry.MapExtension(PKTMessage, xml.Name{Space: NSMsgChatMarkers, Local: "received"}, MarkReceived{})
+	TypeRegistry.MapExtension(PKTMessage, xml.Name{Space: NSMsgChatMarkers, Local: "displayed"}, MarkDisplayed{})
+	TypeRegistry.MapExtension(PKTMessage, xml.Name{Space: NSMsgChatMarkers, Local: "acknowledged"}, MarkAcknowledged{})
 }

--- a/stanza/msg_chat_state.go
+++ b/stanza/msg_chat_state.go
@@ -37,9 +37,9 @@ type StatePaused struct {
 }
 
 func init() {
-	TypeRegistry.MapExtension(PKTMessage, xml.Name{NSMsgChatStateNotifications, "active"}, StateActive{})
-	TypeRegistry.MapExtension(PKTMessage, xml.Name{NSMsgChatStateNotifications, "composing"}, StateComposing{})
-	TypeRegistry.MapExtension(PKTMessage, xml.Name{NSMsgChatStateNotifications, "gone"}, StateGone{})
-	TypeRegistry.MapExtension(PKTMessage, xml.Name{NSMsgChatStateNotifications, "inactive"}, StateInactive{})
-	TypeRegistry.MapExtension(PKTMessage, xml.Name{NSMsgChatStateNotifications, "paused"}, StatePaused{})
+	TypeRegistry.MapExtension(PKTMessage, xml.Name{Space: NSMsgChatStateNotifications, Local: "active"}, StateActive{})
+	TypeRegistry.MapExtension(PKTMessage, xml.Name{Space: NSMsgChatStateNotifications, Local: "composing"}, StateComposing{})
+	TypeRegistry.MapExtension(PKTMessage, xml.Name{Space: NSMsgChatStateNotifications, Local: "gone"}, StateGone{})
+	TypeRegistry.MapExtension(PKTMessage, xml.Name{Space: NSMsgChatStateNotifications, Local: "inactive"}, StateInactive{})
+	TypeRegistry.MapExtension(PKTMessage, xml.Name{Space: NSMsgChatStateNotifications, Local: "paused"}, StatePaused{})
 }

--- a/stanza/msg_html.go
+++ b/stanza/msg_html.go
@@ -18,5 +18,5 @@ type HTMLBody struct {
 }
 
 func init() {
-	TypeRegistry.MapExtension(PKTMessage, xml.Name{"http://jabber.org/protocol/xhtml-im", "html"}, HTML{})
+	TypeRegistry.MapExtension(PKTMessage, xml.Name{Space: "http://jabber.org/protocol/xhtml-im", Local: "html"}, HTML{})
 }

--- a/stanza/msg_oob.go
+++ b/stanza/msg_oob.go
@@ -17,5 +17,5 @@ type OOB struct {
 }
 
 func init() {
-	TypeRegistry.MapExtension(PKTMessage, xml.Name{"jabber:x:oob", "x"}, OOB{})
+	TypeRegistry.MapExtension(PKTMessage, xml.Name{Space: "jabber:x:oob", Local: "x"}, OOB{})
 }

--- a/stanza/msg_pubsub_event.go
+++ b/stanza/msg_pubsub_event.go
@@ -210,5 +210,4 @@ func (pse *PubSubEvent) UnmarshalXML(d *xml.Decoder, start xml.StartElement) err
 		}
 
 	}
-	return nil
 }

--- a/stanza/msg_receipts.go
+++ b/stanza/msg_receipts.go
@@ -24,6 +24,6 @@ type ReceiptReceived struct {
 }
 
 func init() {
-	TypeRegistry.MapExtension(PKTMessage, xml.Name{NSMsgReceipts, "request"}, ReceiptRequest{})
-	TypeRegistry.MapExtension(PKTMessage, xml.Name{NSMsgReceipts, "received"}, ReceiptReceived{})
+	TypeRegistry.MapExtension(PKTMessage, xml.Name{Space: NSMsgReceipts, Local: "request"}, ReceiptRequest{})
+	TypeRegistry.MapExtension(PKTMessage, xml.Name{Space: NSMsgReceipts, Local: "received"}, ReceiptReceived{})
 }

--- a/stanza/node_test.go
+++ b/stanza/node_test.go
@@ -8,7 +8,10 @@ import (
 func TestNode_Marshal(t *testing.T) {
 	jsonData := []byte("{\"key\":\"value\"}")
 
-	iqResp := NewIQ(Attrs{Type: "result", From: "admin@localhost", To: "test@localhost", Id: "1"})
+	iqResp, err := NewIQ(Attrs{Type: "result", From: "admin@localhost", To: "test@localhost", Id: "1"})
+	if err != nil {
+		t.Fatalf("failed to create IQ: %v", err)
+	}
 	iqResp.Any = &Node{
 		XMLName: xml.Name{Space: "myNS", Local: "space"},
 		Content: string(jsonData),

--- a/stanza/pres_muc.go
+++ b/stanza/pres_muc.go
@@ -144,5 +144,5 @@ func (h History) MarshalXML(e *xml.Encoder, start xml.StartElement) (err error) 
 }
 
 func init() {
-	TypeRegistry.MapExtension(PKTPresence, xml.Name{"http://jabber.org/protocol/muc", "x"}, MucPresence{})
+	TypeRegistry.MapExtension(PKTPresence, xml.Name{Space: "http://jabber.org/protocol/muc", Local: "x"}, MucPresence{})
 }

--- a/stanza/pubsub_owner_test.go
+++ b/stanza/pubsub_owner_test.go
@@ -16,6 +16,9 @@ func TestNewConfigureNode(t *testing.T) {
 		"</pubsub> </iq>"
 
 	subR, err := stanza.NewConfigureNode("pubsub.shakespeare.lit", "princely_musings")
+	if err != nil {
+		t.Fatalf("failed to create a configure node request: %v", err)
+	}
 	subR.Id = "config1"
 	if err != nil {
 		t.Fatalf("Could not create request : %s", err)
@@ -129,6 +132,9 @@ func TestNewRequestDefaultConfig(t *testing.T) {
 		"<pubsub xmlns=\"http://jabber.org/protocol/pubsub#owner\"> <default></default> </pubsub> </iq>"
 
 	subR, err := stanza.NewRequestDefaultConfig("pubsub.shakespeare.lit")
+	if err != nil {
+		t.Fatalf("failed to create a default config request: %v", err)
+	}
 	subR.Id = "def1"
 	if err != nil {
 		t.Fatalf("Could not create request : %s", err)
@@ -239,6 +245,9 @@ func TestNewDelNode(t *testing.T) {
 		"<delete node=\"princely_musings\"></delete> </pubsub> </iq>"
 
 	subR, err := stanza.NewDelNode("pubsub.shakespeare.lit", "princely_musings")
+	if err != nil {
+		t.Fatalf("failed to create a node delete request: %v", err)
+	}
 	subR.Id = "delete1"
 	if err != nil {
 		t.Fatalf("Could not create request : %s", err)
@@ -311,6 +320,9 @@ func TestNewPurgeAllItems(t *testing.T) {
 		"<purge node=\"princely_musings\"></purge> </pubsub> </iq>"
 
 	subR, err := stanza.NewPurgeAllItems("pubsub.shakespeare.lit", "princely_musings")
+	if err != nil {
+		t.Fatalf("failed to create a purge all items request: %v", err)
+	}
 	subR.Id = "purge1"
 	if err != nil {
 		t.Fatalf("Could not create request : %s", err)
@@ -367,6 +379,9 @@ func TestNewApproveSubRequest(t *testing.T) {
 	}
 
 	subR, err := stanza.NewApproveSubRequest("pubsub.shakespeare.lit", "approve1", apprForm)
+	if err != nil {
+		t.Fatalf("failed to create a sub approval request: %v", err)
+	}
 	subR.Id = "approve1"
 	if err != nil {
 		t.Fatalf("Could not create request : %s", err)
@@ -404,6 +419,9 @@ func TestNewGetPendingSubRequests(t *testing.T) {
 		"</command> </iq>"
 
 	subR, err := stanza.NewGetPendingSubRequests("pubsub.shakespeare.lit")
+	if err != nil {
+		t.Fatalf("failed to create a get pending subs request: %v", err)
+	}
 	subR.Id = "pending1"
 	if err != nil {
 		t.Fatalf("Could not create request : %s", err)
@@ -461,12 +479,12 @@ func TestNewGetPendingSubRequestsResp(t *testing.T) {
 
 	_, ok := respIQ.Payload.(*stanza.Command)
 	if !ok {
-		errors.New("this iq payload is not a command")
+		t.Fatal("this iq payload is not a command")
 	}
 
 	fMap, err := respIQ.GetFormFields()
 	if err != nil || len(fMap) != 2 {
-		errors.New("could not parse command form fields")
+		t.Fatal("could not parse command form fields")
 	}
 
 }
@@ -485,6 +503,9 @@ func TestNewApprovePendingSubRequest(t *testing.T) {
 	subR, err := stanza.NewApprovePendingSubRequest("pubsub.shakespeare.lit",
 		"pubsub-get-pending:20031021T150901Z-600",
 		"princely_musings")
+	if err != nil {
+		t.Fatalf("failed to create a approve pending sub request: %v", err)
+	}
 	subR.Id = "pending2"
 	if err != nil {
 		t.Fatalf("Could not create request : %s", err)
@@ -524,6 +545,9 @@ func TestNewSubListRqPl(t *testing.T) {
 		"<subscriptions node=\"princely_musings\"></subscriptions> </pubsub> </iq>"
 
 	subR, err := stanza.NewSubListRqPl("pubsub.shakespeare.lit", "princely_musings")
+	if err != nil {
+		t.Fatalf("failed to create a sub list request: %v", err)
+	}
 	subR.Id = "subman1"
 	if err != nil {
 		t.Fatalf("Could not create request : %s", err)
@@ -575,7 +599,7 @@ func TestNewSubListRqPlResp(t *testing.T) {
 
 	pubsub, ok := respIQ.Payload.(*stanza.PubSubOwner)
 	if !ok {
-		errors.New("this iq payload is not a command")
+		t.Fatal("this iq payload is not a command")
 	}
 
 	subs, ok := pubsub.OwnerUseCase.(*stanza.SubscriptionsOwner)
@@ -599,6 +623,9 @@ func TestNewAffiliationListRequest(t *testing.T) {
 		"<affiliations node=\"princely_musings\"></affiliations> </pubsub> </iq>"
 
 	subR, err := stanza.NewAffiliationListRequest("pubsub.shakespeare.lit", "princely_musings")
+	if err != nil {
+		t.Fatalf("failed to create an affiliations list request: %v", err)
+	}
 	subR.Id = "ent1"
 	if err != nil {
 		t.Fatalf("Could not create request : %s", err)
@@ -648,7 +675,7 @@ func TestNewAffiliationListRequestResp(t *testing.T) {
 
 	pubsub, ok := respIQ.Payload.(*stanza.PubSubOwner)
 	if !ok {
-		errors.New("this iq payload is not a command")
+		t.Fatal("this iq payload is not a command")
 	}
 
 	affils, ok := pubsub.OwnerUseCase.(*stanza.AffiliationsOwner)
@@ -690,6 +717,9 @@ func TestNewModifAffiliationRequest(t *testing.T) {
 	}
 
 	subR, err := stanza.NewModifAffiliationRequest("pubsub.shakespeare.lit", "princely_musings", affils)
+	if err != nil {
+		t.Fatalf("failed to create a modif affiliation request: %v", err)
+	}
 	subR.Id = "ent3"
 	if err != nil {
 		t.Fatalf("Could not create request : %s", err)
@@ -833,6 +863,10 @@ func TestNewFormSubmissionOwner(t *testing.T) {
 			{Var: "pubsub#access_model", ValuesList: []string{"roster"}},
 			{Var: "pubsub#roster_groups_allowed", ValuesList: []string{"friends", "servants", "courtiers"}},
 		})
+	if err != nil {
+		t.Fatalf("failed to create a form submission request: %v", err)
+	}
+
 	subR.Id = "config2"
 	if err != nil {
 		t.Fatalf("Could not create request : %s", err)
@@ -878,7 +912,7 @@ func getPubSubOwnerPayload(response string) (*stanza.PubSubOwner, error) {
 
 	pubsub, ok := respIQ.Payload.(*stanza.PubSubOwner)
 	if !ok {
-		errors.New("this iq payload is not a pubsub of the owner namespace")
+		return nil, errors.New("this iq payload is not a pubsub of the owner namespace")
 	}
 
 	return pubsub, nil

--- a/stanza/pubsub_test.go
+++ b/stanza/pubsub_test.go
@@ -40,6 +40,9 @@ func TestNewSubRequest(t *testing.T) {
 		Node: "princely_musings", Jid: "francisco@denmark.lit",
 	}
 	subR, err := stanza.NewSubRq("pubsub.shakespeare.lit", subInfo)
+	if err != nil {
+		t.Fatalf("failed to create a sub request: %v", err)
+	}
 	subR.Id = "sub1"
 	if err != nil {
 		t.Fatalf("Could not create a sub request : %s", err)
@@ -96,6 +99,9 @@ func TestNewUnSubRequest(t *testing.T) {
 		Node: "princely_musings", Jid: "francisco@denmark.lit",
 	}
 	subR, err := stanza.NewUnsubRq("pubsub.shakespeare.lit", subInfo)
+	if err != nil {
+		t.Fatalf("failed to create an unsub request: %v", err)
+	}
 	subR.Id = "unsub1"
 	if err != nil {
 		t.Fatalf("Could not create a sub request : %s", err)
@@ -157,6 +163,9 @@ func TestNewSubOptsRq(t *testing.T) {
 		Node: "princely_musings", Jid: "francisco@denmark.lit",
 	}
 	subR, err := stanza.NewSubOptsRq("pubsub.shakespeare.lit", subInfo)
+	if err != nil {
+		t.Fatalf("failed to create a sub options request: %v", err)
+	}
 	subR.Id = "options1"
 	if err != nil {
 		t.Fatalf("Could not create a sub request : %s", err)
@@ -264,6 +273,9 @@ func TestNewFormSubmission(t *testing.T) {
 	}
 
 	subR, err := stanza.NewFormSubmission("pubsub.shakespeare.lit", subInfo, submitFormExample)
+	if err != nil {
+		t.Fatalf("failed to create a form submission request: %v", err)
+	}
 	subR.Id = "options2"
 	if err != nil {
 		t.Fatalf("Could not create a sub request : %s", err)
@@ -313,6 +325,9 @@ func TestNewSubAndConfig(t *testing.T) {
 	}
 
 	subR, err := stanza.NewSubAndConfig("pubsub.shakespeare.lit", subInfo, submitFormExample)
+	if err != nil {
+		t.Fatalf("failed to create a sub and config request: %v", err)
+	}
 	subR.Id = "sub1"
 	if err != nil {
 		t.Fatalf("Could not create a sub request : %s", err)
@@ -482,6 +497,9 @@ func TestNewSpecificItemRequest(t *testing.T) {
 		"<item id=\"ae890ac52d0df67ed7cfdf51b644e901\"></item> </items> </pubsub> </iq>"
 
 	subR, err := stanza.NewSpecificItemRequest("pubsub.shakespeare.lit", "princely_musings", "ae890ac52d0df67ed7cfdf51b644e901")
+	if err != nil {
+		t.Fatalf("failed to create a specific item request: %v", err)
+	}
 	subR.Id = "items3"
 	if err != nil {
 		t.Fatalf("Could not create an items request : %s", err)
@@ -638,6 +656,9 @@ func TestNewDelItemFromNode(t *testing.T) {
 		"<item id=\"ae890ac52d0df67ed7cfdf51b644e901\"></item> </retract> </pubsub> </iq>"
 
 	subR, err := stanza.NewDelItemFromNode("pubsub.shakespeare.lit", "princely_musings", "ae890ac52d0df67ed7cfdf51b644e901", nil)
+	if err != nil {
+		t.Fatalf("failed to create a delete item from node request: %v", err)
+	}
 	subR.Id = "retract1"
 	if err != nil {
 		t.Fatalf("Could not create a del item request : %s", err)
@@ -677,6 +698,9 @@ func TestNewCreateNode(t *testing.T) {
 		"<pubsub xmlns=\"http://jabber.org/protocol/pubsub\"> <create node=\"princely_musings\"></create> </pubsub> </iq>"
 
 	subR, err := stanza.NewCreateNode("pubsub.shakespeare.lit", "princely_musings")
+	if err != nil {
+		t.Fatalf("failed to create a create node request: %v", err)
+	}
 	subR.Id = "create1"
 	if err != nil {
 		t.Fatalf("Could not create a create node request : %s", err)
@@ -748,6 +772,10 @@ func TestNewCreateAndConfigNode(t *testing.T) {
 				{Var: "pubsub#max_payload_size", ValuesList: []string{"1028"}},
 			},
 		})
+
+	if err != nil {
+		t.Fatalf("failed to create a create and config node request: %v", err)
+	}
 	subR.Id = "create1"
 	if err != nil {
 		t.Fatalf("Could not create a create node request : %s", err)
@@ -796,6 +824,9 @@ func TestNewRetrieveAllSubsRequest(t *testing.T) {
 		"<pubsub xmlns=\"http://jabber.org/protocol/pubsub\"> <subscriptions></subscriptions> </pubsub> </iq>"
 
 	subR, err := stanza.NewRetrieveAllSubsRequest("pubsub.shakespeare.lit")
+	if err != nil {
+		t.Fatalf("failed to create a get all subs request: %v", err)
+	}
 	subR.Id = "subscriptions1"
 	if err != nil {
 		t.Fatalf("Could not create a create node request : %s", err)
@@ -856,6 +887,9 @@ func TestNewRetrieveAllAffilsRequest(t *testing.T) {
 		"<pubsub xmlns=\"http://jabber.org/protocol/pubsub\"> <affiliations></affiliations> </pubsub> </iq>"
 
 	subR, err := stanza.NewRetrieveAllAffilsRequest("pubsub.shakespeare.lit")
+	if err != nil {
+		t.Fatalf("failed to create a get all affiliations request: %v", err)
+	}
 	subR.Id = "affil1"
 	if err != nil {
 		t.Fatalf("Could not create retreive all affiliations request : %s", err)
@@ -914,7 +948,7 @@ func getPubSubGenericPayload(response string) (*stanza.PubSubGeneric, error) {
 
 	pubsub, ok := respIQ.Payload.(*stanza.PubSubGeneric)
 	if !ok {
-		errors.New("this iq payload is not a pubsub")
+		return nil, errors.New("this iq payload is not a pubsub")
 	}
 
 	return pubsub, nil

--- a/stanza/results_sets.go
+++ b/stanza/results_sets.go
@@ -1,0 +1,29 @@
+package stanza
+
+import (
+	"encoding/xml"
+)
+
+// Support for XEP-0059
+// See https://xmpp.org/extensions/xep-0059
+const (
+	// Common but not only possible namespace for query blocks in a result set context
+	NSQuerySet = "jabber:iq:search"
+)
+
+type ResultSet struct {
+	XMLName xml.Name `xml:"http://jabber.org/protocol/rsm set"`
+	After   *string  `xml:"after,omitempty"`
+	Before  *string  `xml:"before,omitempty"`
+	Count   *int     `xml:"count,omitempty"`
+	First   *First   `xml:"first,omitempty"`
+	Index   *int     `xml:"index,omitempty"`
+	Last    *string  `xml:"last,omitempty"`
+	Max     *int     `xml:"max,omitempty"`
+}
+
+type First struct {
+	XMLName xml.Name `xml:"first"`
+	Content string
+	Index   *int `xml:"index,attr,omitempty"`
+}

--- a/stanza/results_sets_test.go
+++ b/stanza/results_sets_test.go
@@ -1,79 +1,28 @@
 package stanza_test
 
 import (
-	"encoding/xml"
 	"gosrc.io/xmpp/stanza"
 	"testing"
 )
 
 // Limiting the number of items
 func TestNewResultSetReq(t *testing.T) {
-	expectedRq := "<iq type=\"set\" id=\"limit1\" to=\"users.jabber.org\"> <query xmlns=\"jabber:iq:search\"> " +
-		"<nick>Pete</nick> <set xmlns=\"http://jabber.org/protocol/rsm\"> <max>10</max> </set> </query> </iq>"
-
-	items := []stanza.Node{
-		{
-			XMLName: xml.Name{Local: "nick"},
-			Content: "Pete",
-		},
-	}
+	expectedRq := "<iq id=\"q29302\" type=\"set\"> <query xmlns=\"urn:xmpp:mam:2\"> " +
+		"<x type=\"submit\" xmlns=\"jabber:x:data\"> <field type=\"hidden\" var=\"FORM_TYPE\"> " +
+		"<value>urn:xmpp:mam:2</value> </field> <field var=\"start\"> <value>2010-08-07T00:00:00Z</value> </field> </x> " +
+		"<set xmlns=\"http://jabber.org/protocol/rsm\"> <max>10</max> </set> </query> </iq>"
 
 	maxVal := 10
 	rs := &stanza.ResultSet{
 		Max: &maxVal,
 	}
 
-	rq, err := stanza.NewResultSetReq("users.jabber.org", "jabber:iq:search", items, rs)
-	if err != nil {
-		t.Fatalf("failed to build the result set request : %v", err)
-	}
-	rq.Id = "limit1"
-
-	data, err := xml.Marshal(rq)
-	if err := compareMarshal(expectedRq, string(data)); err != nil {
-		t.Fatalf(err.Error())
-	}
+	// TODO when Mam is implemented
+	_ = expectedRq
+	_ = rs
 }
 
 func TestUnmarshalResultSeqReq(t *testing.T) {
-	//expectedRq := "<iq type=\"set\" id=\"limit1\" to=\"users.jabber.org\"> <query xmlns=\"jabber:iq:search\"> " +
-	//	"<nick>Pete</nick> <set xmlns=\"http://jabber.org/protocol/rsm\"> <max>10</max> </set> </query> </iq>"
-	//var uReq stanza.IQ
-	//err := xml.Unmarshal([]byte(expectedRq), &uReq)
-	//if err != nil {
-	//	t.Fatalf(err.Error())
-	//}
-	//items := []stanza.Node{
-	//	{
-	//		XMLName: xml.Name{Local: "nick"},
-	//		Content: "Pete",
-	//	},
-	//}
-	//
-	//maxVal := 10
-	//rs := &stanza.ResultSet{
-	//	XMLName: xml.Name{Local: "set", Space: "http://jabber.org/protocol/rsm"},
-	//	Max:     &maxVal,
-	//}
-	//
-	//rq, err := stanza.NewResultSetReq("users.jabber.org", "jabber:iq:search", items, rs)
-	//if err != nil {
-	//	t.Fatalf("failed to build the result set request : %v", err)
-	//}
-	//rq.Id = "limit1"
-	//
-	//// Namespace is unmarshalled as of parent for nodes in the payload. To DeepEqual, we need to set the namespace in
-	//// the "expectedRq"
-	//n, ok := rq.Payload.(*stanza.QuerySet)
-	//if !ok {
-	//	t.Fatalf("payload is not a query set: %v", ok)
-	//}
-	//n.Nodes[0].XMLName.Space = stanza.NSQuerySet
-	//
-	//data, err := xml.Marshal(rq)
-	//fmt.Println(string(data))
-	//if !reflect.DeepEqual(rq, uReq) {
-	//	t.Fatalf("nope")
-	//}
+	// TODO when Mam is implemented
 
 }

--- a/stanza/results_sets_test.go
+++ b/stanza/results_sets_test.go
@@ -1,0 +1,79 @@
+package stanza_test
+
+import (
+	"encoding/xml"
+	"gosrc.io/xmpp/stanza"
+	"testing"
+)
+
+// Limiting the number of items
+func TestNewResultSetReq(t *testing.T) {
+	expectedRq := "<iq type=\"set\" id=\"limit1\" to=\"users.jabber.org\"> <query xmlns=\"jabber:iq:search\"> " +
+		"<nick>Pete</nick> <set xmlns=\"http://jabber.org/protocol/rsm\"> <max>10</max> </set> </query> </iq>"
+
+	items := []stanza.Node{
+		{
+			XMLName: xml.Name{Local: "nick"},
+			Content: "Pete",
+		},
+	}
+
+	maxVal := 10
+	rs := &stanza.ResultSet{
+		Max: &maxVal,
+	}
+
+	rq, err := stanza.NewResultSetReq("users.jabber.org", "jabber:iq:search", items, rs)
+	if err != nil {
+		t.Fatalf("failed to build the result set request : %v", err)
+	}
+	rq.Id = "limit1"
+
+	data, err := xml.Marshal(rq)
+	if err := compareMarshal(expectedRq, string(data)); err != nil {
+		t.Fatalf(err.Error())
+	}
+}
+
+func TestUnmarshalResultSeqReq(t *testing.T) {
+	//expectedRq := "<iq type=\"set\" id=\"limit1\" to=\"users.jabber.org\"> <query xmlns=\"jabber:iq:search\"> " +
+	//	"<nick>Pete</nick> <set xmlns=\"http://jabber.org/protocol/rsm\"> <max>10</max> </set> </query> </iq>"
+	//var uReq stanza.IQ
+	//err := xml.Unmarshal([]byte(expectedRq), &uReq)
+	//if err != nil {
+	//	t.Fatalf(err.Error())
+	//}
+	//items := []stanza.Node{
+	//	{
+	//		XMLName: xml.Name{Local: "nick"},
+	//		Content: "Pete",
+	//	},
+	//}
+	//
+	//maxVal := 10
+	//rs := &stanza.ResultSet{
+	//	XMLName: xml.Name{Local: "set", Space: "http://jabber.org/protocol/rsm"},
+	//	Max:     &maxVal,
+	//}
+	//
+	//rq, err := stanza.NewResultSetReq("users.jabber.org", "jabber:iq:search", items, rs)
+	//if err != nil {
+	//	t.Fatalf("failed to build the result set request : %v", err)
+	//}
+	//rq.Id = "limit1"
+	//
+	//// Namespace is unmarshalled as of parent for nodes in the payload. To DeepEqual, we need to set the namespace in
+	//// the "expectedRq"
+	//n, ok := rq.Payload.(*stanza.QuerySet)
+	//if !ok {
+	//	t.Fatalf("payload is not a query set: %v", ok)
+	//}
+	//n.Nodes[0].XMLName.Space = stanza.NSQuerySet
+	//
+	//data, err := xml.Marshal(rq)
+	//fmt.Println(string(data))
+	//if !reflect.DeepEqual(rq, uReq) {
+	//	t.Fatalf("nope")
+	//}
+
+}

--- a/stanza/sasl_auth.go
+++ b/stanza/sasl_auth.go
@@ -69,10 +69,16 @@ type Bind struct {
 	XMLName  xml.Name `xml:"urn:ietf:params:xml:ns:xmpp-bind bind"`
 	Resource string   `xml:"resource,omitempty"`
 	Jid      string   `xml:"jid,omitempty"`
+	// Result sets
+	ResultSet *ResultSet `xml:"set,omitempty"`
 }
 
 func (b *Bind) Namespace() string {
 	return b.XMLName.Space
+}
+
+func (b *Bind) GetSet() *ResultSet {
+	return b.ResultSet
 }
 
 // ============================================================================
@@ -89,10 +95,16 @@ func (b *Bind) Namespace() string {
 type StreamSession struct {
 	XMLName  xml.Name `xml:"urn:ietf:params:xml:ns:xmpp-session session"`
 	Optional bool     // If element does exist, it mean we are not required to open session
+	// Result sets
+	ResultSet *ResultSet `xml:"set,omitempty"`
 }
 
 func (s *StreamSession) Namespace() string {
 	return s.XMLName.Space
+}
+
+func (s *StreamSession) GetSet() *ResultSet {
+	return s.ResultSet
 }
 
 func (s *StreamSession) IsOptional() bool {

--- a/stanza/sasl_auth_test.go
+++ b/stanza/sasl_auth_test.go
@@ -28,7 +28,10 @@ func TestSessionFeatures(t *testing.T) {
 
 // Check that the Session tag can be used in IQ decoding
 func TestSessionIQ(t *testing.T) {
-	iq := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeSet, Id: "session"})
+	iq, err := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeSet, Id: "session"})
+	if err != nil {
+		t.Fatalf("failed to create IQ: %v", err)
+	}
 	iq.Payload = &stanza.StreamSession{XMLName: xml.Name{Local: "session"}, Optional: true}
 
 	data, err := xml.Marshal(iq)

--- a/stanza/xmpp_test.go
+++ b/stanza/xmpp_test.go
@@ -16,7 +16,7 @@ var reInsideWhtsp = regexp.MustCompile(`[\s\p{Zs}]`)
 // ============================================================================
 // Marshaller / unmarshaller test
 
-func checkMarshalling(t *testing.T, iq stanza.IQ) (*stanza.IQ, error) {
+func checkMarshalling(t *testing.T, iq *stanza.IQ) (*stanza.IQ, error) {
 	// Marshall
 	data, err := xml.Marshal(iq)
 	if err != nil {

--- a/stream_manager.go
+++ b/stream_manager.go
@@ -27,7 +27,7 @@ type StreamClient interface {
 	Connect() error
 	Resume(state SMState) error
 	Send(packet stanza.Packet) error
-	SendIQ(ctx context.Context, iq stanza.IQ) (chan stanza.IQ, error)
+	SendIQ(ctx context.Context, iq *stanza.IQ) (chan stanza.IQ, error)
 	SendRaw(packet string) error
 	Disconnect() error
 	SetHandler(handler EventHandler)
@@ -37,7 +37,7 @@ type StreamClient interface {
 // It is mostly use in callback to pass a limited subset of the stream client interface
 type Sender interface {
 	Send(packet stanza.Packet) error
-	SendIQ(ctx context.Context, iq stanza.IQ) (chan stanza.IQ, error)
+	SendIQ(ctx context.Context, iq *stanza.IQ) (chan stanza.IQ, error)
 	SendRaw(packet string) error
 }
 

--- a/tcp_server_mock.go
+++ b/tcp_server_mock.go
@@ -130,13 +130,16 @@ func respondToIQ(t *testing.T, sc *ServerConn) {
 		t.Fatalf("failed to receive IQ : %s", err.Error())
 	}
 
-	if !iqReq.IsValid() {
+	if vld, _ := iqReq.IsValid(); !vld {
 		mockIQError(sc.connection)
 		return
 	}
 
 	// Crafting response
-	iqResp := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeResult, From: iqReq.To, To: iqReq.From, Id: iqReq.Id, Lang: "en"})
+	iqResp, err := stanza.NewIQ(stanza.Attrs{Type: stanza.IQTypeResult, From: iqReq.To, To: iqReq.From, Id: iqReq.Id, Lang: "en"})
+	if err != nil {
+		t.Fatalf("failed to create iqResp: %v", err)
+	}
 	disco := iqResp.DiscoInfo()
 	disco.AddFeatures("vcard-temp",
 		`http://jabber.org/protocol/address`)

--- a/transport.go
+++ b/transport.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 )
 
-var ErrTransportProtocolNotSupported = errors.New("Transport protocol not supported")
-var ErrTLSNotSupported = errors.New("Transport does not support StartTLS")
+var ErrTransportProtocolNotSupported = errors.New("transport protocol not supported")
+var ErrTLSNotSupported = errors.New("transport does not support StartTLS")
 
 // TODO: rename to transport config?
 type TransportConfiguration struct {
@@ -67,7 +67,7 @@ func NewClientTransport(config TransportConfiguration) Transport {
 // will be returned.
 func NewComponentTransport(config TransportConfiguration) (Transport, error) {
 	if strings.HasPrefix(config.Address, "ws:") || strings.HasPrefix(config.Address, "wss:") {
-		return nil, fmt.Errorf("Components only support XMPP transport: %w", ErrTransportProtocolNotSupported)
+		return nil, fmt.Errorf("components only support XMPP transport: %w", ErrTransportProtocolNotSupported)
 	}
 
 	config.Address = ensurePort(config.Address, 5222)

--- a/xmpp_transport.go
+++ b/xmpp_transport.go
@@ -113,7 +113,7 @@ func (t *XMPPTransport) Ping() error {
 		return err
 	}
 	if n != 1 {
-		return errors.New("Could not write ping")
+		return errors.New("could not write ping")
 	}
 	return nil
 }


### PR DESCRIPTION
- Changed IQ stanzas to pointer semantics
- Fixed commands from v 0.4.0 and tests
- Added primitive Result Sets support (XEP-0059)
- Tests for Result sets are not implemented yet. Result sets seem to be fairly unused across servers and is a little weird to test without a specific implementing XEP like XEP-0313; because the implementations are different across XEPs. Therefore, as 313 is coming, I'll update the tests for XEP-0059 with it.

