### PR TITLE
modify sample code of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ func main() {
 	router := xmpp.NewRouter()
 	router.HandleFunc("message", handleMessage)
 
-	client, err := xmpp.NewClient(config, router, errorHandler)
+	client, err := xmpp.NewClient(&config, router, errorHandler)
 	if err != nil {
 		log.Fatalf("%+v", err)
 	}


### PR DESCRIPTION
Sample code of README.md occurs the following error.
```
cannot use config (type xmpp.Config) as type *xmpp.Config in argument to xmpp.NewClient
```