### PR TITLE
Fix marshalling/unmarshalling of command children

### DIFF
--- a/stanza/commands.go
+++ b/stanza/commands.go
@@ -23,7 +23,7 @@ const (
 type Command struct {
 	XMLName xml.Name `xml:"http://jabber.org/protocol/commands command"`
 
-	CommandElement CommandElement
+	CommandElements []CommandElement
 
 	BadAction       *struct{} `xml:"bad-action,omitempty"`
 	BadLocale       *struct{} `xml:"bad-locale,omitempty"`
@@ -124,19 +124,19 @@ func (c *Command) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 			case "actions":
 				a := Actions{}
 				err = d.DecodeElement(&a, &tt)
-				c.CommandElement = &a
+				c.CommandElements = append(c.CommandElements, &a)
 			case "note":
 				nt := Note{}
 				err = d.DecodeElement(&nt, &tt)
-				c.CommandElement = &nt
+				c.CommandElements = append(c.CommandElements, &nt)
 			case "x":
 				f := Form{}
 				err = d.DecodeElement(&f, &tt)
-				c.CommandElement = &f
+				c.CommandElements = append(c.CommandElements, &f)
 			default:
 				n := Node{}
 				err = d.DecodeElement(&n, &tt)
-				c.CommandElement = &n
+				c.CommandElements = append(c.CommandElements, &n)
 				if err != nil {
 					return err
 				}

--- a/stanza/commands.go
+++ b/stanza/commands.go
@@ -56,6 +56,8 @@ type CommandElement interface {
 }
 
 type Actions struct {
+	XMLName xml.Name `xml:"actions"`
+
 	Prev     *struct{} `xml:"prev,omitempty"`
 	Next     *struct{} `xml:"next,omitempty"`
 	Complete *struct{} `xml:"complete,omitempty"`
@@ -68,6 +70,8 @@ func (a *Actions) Ref() string {
 }
 
 type Note struct {
+	XMLName xml.Name `xml:"note"`
+
 	Text string `xml:",cdata"`
 	Type string `xml:"type,attr,omitempty"`
 }
@@ -117,11 +121,11 @@ func (c *Command) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 			var err error
 			switch tt.Name.Local {
 
-			case "affiliations":
+			case "actions":
 				a := Actions{}
 				err = d.DecodeElement(&a, &tt)
 				c.CommandElement = &a
-			case "configure":
+			case "note":
 				nt := Note{}
 				err = d.DecodeElement(&nt, &tt)
 				c.CommandElement = &nt

--- a/stanza/pubsub_owner.go
+++ b/stanza/pubsub_owner.go
@@ -237,10 +237,10 @@ func NewApprovePendingSubRequest(serviceId, sessionId, nodeId string) (*IQ, erro
 	}
 	iq.Payload = &Command{
 		//  the command name ('node' attribute of the command element) MUST have a value of "http://jabber.org/protocol/pubsub#get-pending"
-		Node:           "http://jabber.org/protocol/pubsub#get-pending",
-		Action:         CommandActionExecute,
-		SessionId:      sessionId,
-		CommandElement: &n,
+		Node:            "http://jabber.org/protocol/pubsub#get-pending",
+		Action:          CommandActionExecute,
+		SessionId:       sessionId,
+		CommandElements: []CommandElement{&n},
 	}
 	return iq, nil
 }
@@ -353,11 +353,18 @@ func (iq *IQ) GetFormFields() (map[string]*Field, error) {
 
 	case *Command:
 		fieldMap := make(map[string]*Field)
-		co, ok := payload.CommandElement.(*Form)
-		if !ok {
+		var form *Form
+		for _, ce := range payload.CommandElements {
+			fo, ok := ce.(*Form)
+			if ok {
+				form = fo
+				break
+			}
+		}
+		if form == nil {
 			return nil, errors.New("this IQ does not contain a command payload with a form")
 		}
-		for _, elt := range co.Fields {
+		for _, elt := range form.Fields {
 			fieldMap[elt.Var] = elt
 		}
 		return fieldMap, nil


### PR DESCRIPTION
Seems like the implementation author just copied the unmarshaller from `stanza/pubsub_owner.go` and forgot to change all the strings and to test if they actually work.