### PR TITLE
[client] Set StateDisconnected on Disconnect

### DIFF
--- a/client.go
+++ b/client.go
@@ -298,6 +298,7 @@ func (c *Client) Disconnect() error {
 	if c.transport != nil {
 		return c.transport.Close()
 	}
+	c.CurrentState.setState(StateDisconnected)
 	// No transport so no connection.
 	return nil
 }


### PR DESCRIPTION
This PR is a small update so that when the client's `Disconnect()` function is called, we also set the current state to disconnected. Currently, subsequent `connect` fail with https://github.com/FluuxIO/go-xmpp/blob/7186c058fd8eb4985efa52ed00ddbef30371c211/stream_manager.go#L131 as we never transition the state to disconnected. 