### PR TITLE
stanza: fix dropped error

### DIFF
--- a/stanza/error.go
+++ b/stanza/error.go
@@ -99,6 +99,9 @@ func (x Err) MarshalXML(e *xml.Encoder, start xml.StartElement) (err error) {
 		start.Attr = append(start.Attr, typ)
 	}
 	err = e.EncodeToken(start)
+	if err != nil {
+		return err
+	}
 
 	// SubTags
 	// Reason


### PR DESCRIPTION
This fixes a dropped `err` variable in the `stanza` package.