### PR TITLE
fix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ func main() {
 	router := xmpp.NewRouter()
 	router.HandleFunc("message", handleMessage)
 
-	client, err := xmpp.NewClient(config, router, errorHandler)
+	client, err := xmpp.NewClient(&config, router, errorHandler)
 	if err != nil {
 		log.Fatalf("%+v", err)
 	}


### PR DESCRIPTION
./main.go:27:32: cannot use config (variable of struct type xmpp.Config) as *xmpp.Config value in argument to xmpp.NewClient