### PR TITLE
Reconnect fixes

### DIFF
--- a/client.go
+++ b/client.go
@@ -411,7 +411,8 @@ func (c *Client) recv(keepaliveQuit chan<- struct{}) {
 		case stanza.StreamClosePacket:
 			// TCP messages should arrive in order, so we can expect to get nothing more after this occurs
 			c.transport.ReceivedStreamClose()
-			return
+			c.Disconnect()
+			continue
 		default:
 			c.Session.SMState.Inbound++
 		}

--- a/client.go
+++ b/client.go
@@ -296,7 +296,11 @@ func (c *Client) Resume() error {
 // Disconnect disconnects the client from the server, sending a stream close nonza and closing the TCP connection.
 func (c *Client) Disconnect() error {
 	if c.transport != nil {
-		return c.transport.Close()
+		err := c.transport.Close()
+		if c.Session != nil {
+			c.disconnected(c.Session.SMState)
+		}
+		return err
 	}
 	// No transport so no connection.
 	return nil

--- a/xmpp_transport.go
+++ b/xmpp_transport.go
@@ -43,7 +43,7 @@ func (t *XMPPTransport) Connect() (string, error) {
 		return "", NewConnError(err, true)
 	}
 
-	t.closeChan = make(chan stanza.StreamClosePacket)
+	t.closeChan = make(chan stanza.StreamClosePacket, 1)
 	t.readWriter = newStreamLogger(t.conn, t.logFile)
 	t.decoder = xml.NewDecoder(bufio.NewReaderSize(t.readWriter, maxPacketSize))
 	t.decoder.CharsetReader = t.Config.CharsetReader

--- a/xmpp_transport.go
+++ b/xmpp_transport.go
@@ -35,6 +35,9 @@ var clientStreamOpen = fmt.Sprintf("<?xml version='1.0'?><stream:stream to='%%s'
 func (t *XMPPTransport) Connect() (string, error) {
 	var err error
 
+	// Since we're starting a new connection, reset the encryption status
+	t.isSecure = false
+
 	t.conn, err = net.DialTimeout("tcp", t.Config.Address, time.Duration(t.Config.ConnectTimeout)*time.Second)
 	if err != nil {
 		return "", NewConnError(err, true)


### PR DESCRIPTION
This PR includes multiple small fixes go-xmpp to successfully reconnect when the server sends a `</stream:stream>`.